### PR TITLE
chore(github actions): refine `on` paths

### DIFF
--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -3,13 +3,21 @@ name: Documentation Website CI
 on:
   push:
     branches:
-      - main
+      - 'main'
     paths:
+      # ⬇ Keep paths in sync with `typescript.yml`
       - '.github/**'
+      - '*'
+      - '!Cargo.toml'
+      # ⬆ Keep paths in sync with `typescript.yml`
       - 'apps/documentation/**'
   pull_request:
     paths:
+      # ⬇ Keep paths in sync with `typescript.yml`
       - '.github/**'
+      - '*'
+      - '!Cargo.toml'
+      # ⬆ Keep paths in sync with `typescript.yml`
       - 'apps/documentation/**'
 
 jobs:

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -3,7 +3,7 @@ name: Deploy documentation website on AWS S3
 on:
   push:
     branches:
-      - main
+      - 'main'
     paths:
       - '.github/**'
       - 'apps/documentation/**'

--- a/.github/workflows/repo-root-ci.yml
+++ b/.github/workflows/repo-root-ci.yml
@@ -1,4 +1,5 @@
 name: Repo root CI
+
 # All workflows are triggered based on specific paths,
 # the root repository is something that is not applicable to rust nor typescript
 # so it has been moved in a standalone workflow
@@ -6,14 +7,14 @@ name: Repo root CI
 on:
   push:
     branches:
-      - main
+      - 'main'
     paths:
       - '.github/**'
-      - './*'
+      - '*'
   pull_request:
     paths:
       - '.github/**'
-      - './*'
+      - '*'
 
 jobs:
   build-and-test:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,13 +3,15 @@ name: Rust CI
 on:
   push:
     branches:
-      - main
+      - 'main'
     paths:
       - '.github/**'
+      - 'Cargo.toml'
       - 'crates/**'
   pull_request:
     paths:
       - '.github/**'
+      - 'Cargo.toml'
       - 'crates/**'
 
 env:

--- a/.github/workflows/spell-checking.yml
+++ b/.github/workflows/spell-checking.yml
@@ -3,7 +3,7 @@ name: Spell Checker
 on:
   push:
     branches:
-      - main
+      - 'main'
 
   pull_request:
 

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -3,13 +3,21 @@ name: Typescript CI
 on:
   push:
     branches:
-      - main
+      - 'main'
     paths:
+      # ⬇ Keep paths in sync with `ci-documentation.yml`
       - '.github/**'
+      - '*'
+      - '!Cargo.toml'
+      # ⬆ Keep paths in sync with `ci-documentation.yml`
       - 'packages/**'
   pull_request:
     paths:
+      # ⬇ Keep paths in sync with `ci-documentation.yml`
       - '.github/**'
+      - '*'
+      - '!Cargo.toml'
+      # ⬆ Keep paths in sync with `ci-documentation.yml`
       - 'packages/**'
 
 jobs:


### PR DESCRIPTION
## Context & Description

Related to #185

When changing one or more of the following files

- `package.json`
- `pnpm-lock.yaml`
- `eslint.config.js`
- `tsconfig.json`
- `turbo.json`
- `.nvrc`

both `typescript.yml` and `ci-documentation.yml` should be triggered

----

> [!WARNING]
> Let me know if something similar should be done for `rust.yml`

----

> [!TIP]
> [I have performed a few tests in this example repository](https://github.com/marcalexiei/gitbub-actions-workflow-trigger-playground)
