### PR TITLE
refactor(crates/tuono): build - ssg - disable `zombie_processes` warning and use `TUONO_PORT` to generate server URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 exclude = [
 		"apps/documentation",
-		"examples/wit-mdx",
+		"examples/with-mdx",
 		"examples/tuono-app",
 		"examples/tuono-tutorial",
 		"benches/tuono"

--- a/crates/tuono/src/cli.rs
+++ b/crates/tuono/src/cli.rs
@@ -133,6 +133,8 @@ pub fn app() -> std::io::Result<()> {
                 )
                 .expect("Failed to clone assets into static output folder");
 
+                // the process is killed below so we don't really need to use wait() function
+                #[allow(clippy::zombie_processes)]
                 let mut rust_server = app.run_rust_server();
 
                 let reqwest = reqwest::blocking::Client::builder()
@@ -144,7 +146,8 @@ pub fn app() -> std::io::Result<()> {
                 let mut is_server_ready = false;
 
                 while !is_server_ready {
-                    if reqwest.get("http://localhost:3000").send().is_ok() {
+                    let server_url = format!("http://localhost:{}", TUONO_PORT);
+                    if reqwest.get(server_url).send().is_ok() {
                         is_server_ready = true
                     }
                     // TODO: add maximum tries


### PR DESCRIPTION
## Context & Description

Related to rust 1.83.

You can see the error in this [GitHub action run](https://github.com/tuono-labs/tuono/actions/runs/12184578547/job/33988795069?pr=198).

----

Aiddtionaly I used the `format` function to improve server url creation using `TUONO_PORT` constant when building the site using `--static` flag