### PR TITLE
fix(crates/tuono_lib_macros): remove Cargo.tml warnings

### DIFF
--- a/crates/tuono_lib_macros/Cargo.toml
+++ b/crates/tuono_lib_macros/Cargo.toml
@@ -15,8 +15,7 @@ include = [
 ]
 
 [lib]
-crate_type = ["proc-macro"]
-proc-marco = true
+proc-macro = true
 
 [dependencies]
 syn = { version = "2.0.0", features = ["full"] }


### PR DESCRIPTION
## Context & Description

When running `rust` related commands (e.g.: `cargo build`) I got the following warnings: 

```text
warning: /Users/marcalexiei/development/tuono/crates/tuono_lib_macros/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
(in the `tuono_lib_macros` library target)
warning: /Users/marcalexiei/development/tuono/crates/tuono_lib_macros/Cargo.toml: library `tuono_lib_macros` should only specify `proc-macro = true` instead of setting `crate-type`
warning: /Users/marcalexiei/development/tuono/crates/tuono_lib_macros/Cargo.toml: unused manifest key: lib.proc-marco
```

Using just `proc-macro = true` as suggested by warnings seems to remove all of them.

For reference, I'm using `rust` 1.83 
