### PR TITLE
feat: add cookies to the response

### DIFF
--- a/crates/tuono_lib/Cargo.toml
+++ b/crates/tuono_lib/Cargo.toml
@@ -19,6 +19,7 @@ include = [
 [dependencies]
 ssr_rs = "0.7.0"
 axum = {version = "0.7.5", features = ["json", "ws"]}
+axum-extra = {version = "0.9.6", features = ["cookie"]}
 tokio = { version = "1.37.0", features = ["full"] }
 serde = { version = "1.0.202", features = ["derive"] }
 erased-serde = "0.4.5"

--- a/crates/tuono_lib/src/lib.rs
+++ b/crates/tuono_lib/src/lib.rs
@@ -19,4 +19,5 @@ pub use tuono_lib_macros::{api, handler};
 
 // Re-exports
 pub use axum;
+pub use axum_extra::extract::cookie;
 pub use tokio;

--- a/crates/tuono_lib/src/response.rs
+++ b/crates/tuono_lib/src/response.rs
@@ -129,3 +129,32 @@ impl Response {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_update_the_props_status_and_cookie() {
+        let mut props = Props::new("{}");
+        props.status(StatusCode::NOT_FOUND);
+        props.add_cookie(Cookie::new("test", "cookie"));
+        assert_eq!(props.http_code, StatusCode::NOT_FOUND);
+        assert_eq!(
+            props.cookies.get("test").unwrap(),
+            &Cookie::new("test", "cookie")
+        );
+    }
+
+    #[test]
+    fn should_add_a_cookie_jar() {
+        let mut props = Props::new("{}");
+        props.status(StatusCode::NOT_FOUND);
+        props.add_cookie(Cookie::new("test", "cookie"));
+        assert_eq!(props.http_code, StatusCode::NOT_FOUND);
+        assert_eq!(
+            props.cookies.get("test").unwrap(),
+            &Cookie::new("test", "cookie")
+        );
+    }
+}


### PR DESCRIPTION
## Context & Description

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->

This PR adds the support for reading and passing cookies to the HTTP response.

Passing cookies to the response is now possible by:

```rust
let mut props = Props::new(data);
props.add_cookie(Cookie::new());

return Response::Props(props);
```

The `Cookie` stuct has multiple implementation, so it is also possible to use different syntax like: `props.add_cookie(("name", "value"))`.

Also, `tuono_lib` re-export the `axum-extra::extractor::cookie` lib so that the end user can manage both `CookieJar` and `Cookie` structs

```rust
use tuono_lib::cookie::*;
```

Since the new support for cookies is now also possible to interact with the cookies passed from the `Request` like:

```rust
fn handler(req: Request) -> Response {
     let cookies = CookieJar::from_headers(&req.headers);
}
```

This PR closes https://github.com/tuono-labs/tuono/issues/190