### PR TITLE
chore(eslint): remove `build` folder exclusion

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,6 @@ export default tseslint.config(
   {
     ignores: [
       // #region shared
-      '**/build',
       '**/dist',
       '**/.tuono',
       '**/vite.config.ts.timestamp**',

--- a/packages/tuono/src/build/index.ts
+++ b/packages/tuono/src/build/index.ts
@@ -1,8 +1,10 @@
-import { build, createServer, InlineConfig, mergeConfig } from 'vite'
+import type { InlineConfig } from 'vite'
+import { build, createServer, mergeConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import ViteFsRouter from 'tuono-fs-router-vite-plugin'
 import { LazyLoadingPlugin } from 'tuono-lazy-fn-vite-plugin'
 import mdx from '@mdx-js/rollup'
+
 import { loadConfig, blockingAsync } from './utils'
 
 const VITE_PORT = 3001
@@ -18,14 +20,14 @@ const BASE_CONFIG: InlineConfig = {
   },
   plugins: [
     { enforce: 'pre', ...mdx({ providerImportSource: '@mdx-js/react' }) },
-    // @ts-ignore: TS configuration issue.
+    // @ts-expect-error: TS configuration issue.
     react({ include: /\.(jsx|js|mdx|md|tsx|ts)$/ }),
     ViteFsRouter(),
     LazyLoadingPlugin(),
   ],
 }
 
-const developmentSSRBundle = () => {
+const developmentSSRBundle = (): void => {
   blockingAsync(async () => {
     const config = await loadConfig()
     await build(
@@ -40,8 +42,9 @@ const developmentSSRBundle = () => {
           emptyOutDir: true,
           rollupOptions: {
             input: './.tuono/server-main.tsx',
-            // Silent all logs
-            onLog() {},
+            onLog() {
+              // Silence all logs
+            },
             output: {
               entryFileNames: 'dev-server.js',
               format: 'iife',
@@ -57,7 +60,7 @@ const developmentSSRBundle = () => {
   })
 }
 
-const developmentCSRWatch = () => {
+const developmentCSRWatch = (): void => {
   blockingAsync(async () => {
     const config = await loadConfig()
     const server = await createServer(
@@ -85,7 +88,7 @@ const developmentCSRWatch = () => {
   })
 }
 
-const buildProd = () => {
+const buildProd = (): void => {
   blockingAsync(async () => {
     const config = await loadConfig()
 
@@ -132,7 +135,7 @@ const buildProd = () => {
   })
 }
 
-const buildConfig = () => {
+const buildConfig = (): void => {
   blockingAsync(async () => {
     await build({
       root: '.tuono',

--- a/packages/tuono/src/build/utils.spec.ts
+++ b/packages/tuono/src/build/utils.spec.ts
@@ -14,7 +14,7 @@ describe('loadConfig', () => {
   it('should error if the config does not exist', async () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
-      .mockImplementation(() => {})
+      .mockImplementation(() => undefined)
     await loadConfig()
 
     expect(consoleErrorSpy).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
## Context & Description

all content in any `build` folder in the project were excluded from `ESLint` processing.
E.g.: `packages/tuono/src/build`

This PR removes the exclusion and fix all error inside the above mentioned folder.

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->
