### PR TITLE
refactor(apps/documentation): remove lint errors

### DIFF
--- a/apps/documentation/src/components/sidebar/config.ts
+++ b/apps/documentation/src/components/sidebar/config.ts
@@ -1,26 +1,25 @@
 import type { ReactNode } from 'react'
 
-interface SidebarElementType<T> {
+interface SidebarElementBase<T extends string> {
   type: T
 }
 
-interface SidebarLink extends SidebarElementType<'element'> {
+type SidebarDivider = SidebarElementBase<'divider'>
+
+interface SidebarLink extends SidebarElementBase<'element'> {
   label: string
   href: string
-  children?: SidebarLink[]
+  children?: Array<SidebarLink>
   leftIcon?: ReactNode
 }
 
-interface SidebarTitle extends SidebarElementType<'title'> {
+interface SidebarTitle extends SidebarElementBase<'title'> {
   label: string
 }
 
-type SidebarElements =
-  | SidebarElementType<'divider'>
-  | SidebarLink
-  | SidebarTitle
+type SidebarElement = SidebarDivider | SidebarLink | SidebarTitle
 
-export const sidebarElements: SidebarElements[] = [
+export const sidebarElements: Array<SidebarElement> = [
   {
     type: 'element',
     label: 'Home',


### PR DESCRIPTION
## Context & Description

After https://github.com/tuono-labs/tuono/pull/196 merge, [`apps/documentation` do not pass CI](https://github.com/tuono-labs/tuono/actions/runs/12212363275/job/34070731153)

----

I also made a few refinements in sidebar item types.

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->
