### PR TITLE
fix(packages/tuono): styles are not in the page when running `tuono dev`

### DIFF
--- a/packages/tuono/src/build/index.ts
+++ b/packages/tuono/src/build/index.ts
@@ -32,7 +32,17 @@ function createBaseViteConfigFromTuonoConfig(
 
     plugins: [
       ...(tuonoConfig.vite?.plugins ?? []),
-      react(),
+
+      /**
+       * even if `include` is not a valid option for this
+       * plugin, we have to use it.
+       * If not specified, when running `tuono dev`, the mdx
+       * won't be compiled include any style in the page and it might
+       * seem broken.
+       */
+      // @ts-expect-error see above comment
+      react({ include: /\.(jsx|js|mdx|md|tsx|ts)$/ }),
+
       ViteFsRouter(),
       LazyLoadingPlugin(),
     ],


### PR DESCRIPTION
## Context & Description

Avoid js error involving `react` import when running `tuono dev`.

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->
