### PR TITLE
chore(bug_report): make system-info fields required and add CLI command to retrieve them

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,55 +32,24 @@ body:
       description: If applicable, add screenshots to help explain your problem.
     validations:
       required: false
-  - type: input
-    id: tuono-version
+  - type: textarea
+    id: system-info
     attributes:
-      label: Tuono version
-      placeholder: '[e.g. 0.4.0]'
+      label: System Info
+      description: Output of `npx envinfo --system --npmPackages 'tuono' --binaries --browsers`
+      render: shell
+      placeholder: System, Binaries, Browsers
     validations:
-      required: false
-  - type: input
-    id: os-version
+      required: true
+  - type: textarea
+    id: system-info-rust
     attributes:
-      label: OS
-      placeholder: '[e.g. MacOS, Windows]'
+      label: System info (Rust)
+      description: Output of `rustc --version && cargo --version && tuono --version`
+      render: shell
+      placeholder: 'rustc, cargo and tuono binary version'
     validations:
-      required: false
-  - type: input
-    id: browser-version
-    attributes:
-      label: Browser
-      placeholder: '[e.g. chrome, safari]'
-    validations:
-      required: false
-  - type: input
-    id: node-version
-    attributes:
-      label: Node version
-      placeholder: '[e.g. 20.0.0]'
-    validations:
-      required: false
-  - type: input
-    id: rust-version
-    attributes:
-      label: Rust version
-      placeholder: '[e.g. 1.79.0]'
-    validations:
-      required: false
-  - type: input
-    id: create-version
-    attributes:
-      label: Crate version
-      placeholder: '[e.g. 1.78.0]'
-    validations:
-      required: false
-  - type: input
-    id: node-package-manager-version
-    attributes:
-      label: Node Package Manger version
-      placeholder: '[e.g. pnpm: 9.5.0] '
-    validations:
-      required: false
+      required: true
   - type: textarea
     id: additional-context
     attributes:


### PR DESCRIPTION
## Context & Description

Simplify `bug_report` template.

### Remove single field related to system info

- Tuono version
- OS
- Browser version
- Node version
- Rust version
- Crate version
- Node package manager version

###  Added `system-info` field

This is a required field, and its value should be the output from running
```shell
npx envinfo --system --npmPackages 'tuono' --binaries --browsers`
```

Example:

```shell
  System:
    OS: macOS 15.2
    CPU: (8) arm64 Apple M3
    Memory: 101.11 MB / 16.00 GB
    Shell: 5.9 - /bin/zsh
  Binaries:
    Node: 22.11.0 - ~/.nvm/versions/node/v22.11.0/bin/node
    npm: 10.9.0 - ~/.nvm/versions/node/v22.11.0/bin/npm
    pnpm: 9.12.3 - ~/.nvm/versions/node/v22.11.0/bin/pnpm
  Browsers:
    Chrome: 131.0.6778.205
    Safari: 18.2
  npmPackages:
    tuono: 0.16.4 => 0.16.4
```

###  Added `system-info-rust` field

This is a required field, and its value should be the output from running
```shell
rustc --version && cargo --version && tuono --version
```

Example:

```shell
rustc 1.83.0 (90b35a623 2024-11-26)
cargo 1.83.0 (5ffbef321 2024-10-29)
tuono 0.16.4
```

----

[A preview of the template can be seen on this page](https://github.com/tuono-labs/tuono/blob/0f7e7d637b9fc62a23525ab726fd767aa9f57eaa/.github/ISSUE_TEMPLATE/bug_report.yml)

