### PR TITLE
chore: add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 80


### PR DESCRIPTION
## Context & Description

At the moment we use [prettier](https://prettier.io) as code formatter, however if a user editor doesn't support it (natively or by extension) we might end up with an inconsistent formatting.
Adding [`.editorconfig`](https://editorconfig.org) should mitigate this kind of problems since is supported in a wider range of code editors. 

> [!NOTE]
> other formatting issue might arise, but at least they won't involve space or tabs formatting 😅