### PR TITLE
refactor(packages/*): use `@vitejs/plugin-react-swc` and make all package dependencies explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,20 +24,15 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "9.15.0",
-    "@tanstack/config": "^0.7.0",
-    "@types/node": "^22.0.0",
-    "@types/react": "^18.3.13",
-    "@vitejs/plugin-react": "^4.2.1",
-    "eslint": "^9.15.0",
-    "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-plugin-import": "^2.31.0",
+    "@types/node": "22.10.0",
+    "eslint": "9.15.0",
+    "eslint-import-resolver-typescript": "3.6.3",
+    "eslint-plugin-import": "2.31.0",
     "eslint-plugin-react": "7.37.2",
     "eslint-plugin-react-hooks": "5.1.0",
-    "prettier": "^3.2.4",
-    "turbo": "^2.2.3",
+    "prettier": "3.4.1",
+    "turbo": "2.2.3",
     "typescript": "5.6.3",
-    "typescript-eslint": "8.15.0",
-    "vite": "^5.2.11",
-    "vitest": "^2.0.0"
+    "typescript-eslint": "8.15.0"
   }
 }

--- a/packages/fs-router-vite-plugin/package.json
+++ b/packages/fs-router-vite-plugin/package.json
@@ -50,7 +50,7 @@
     "vite": "^5.2.11"
   },
   "devDependencies": {
-    "@tanstack/config": "^0.7.11",
+    "@tanstack/config": "0.7.13",
     "@types/babel__core": "^7.20.5",
     "vitest": "^2.0.0"
   }

--- a/packages/lazy-fn-vite-plugin/package.json
+++ b/packages/lazy-fn-vite-plugin/package.json
@@ -49,7 +49,7 @@
     "vite": "^5.2.11"
   },
   "devDependencies": {
-    "@tanstack/config": "^0.7.11",
+    "@tanstack/config": "0.7.13",
     "@types/babel__core": "^7.20.5",
     "prettier": "^3.2.4",
     "vitest": "^2.0.0"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -44,8 +44,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "react": ">=16.3.0",
-    "react-dom": ">=16.3.0"
+    "react": ">=16.3.0"
   },
   "dependencies": {
     "react-intersection-observer": "^9.13.0",
@@ -53,11 +52,13 @@
     "zustand": "4.4.7"
   },
   "devDependencies": {
-    "@tanstack/config": "^0.7.11",
+    "@tanstack/config": "0.7.13",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.0",
+    "@types/react": "18.3.13",
+    "@vitejs/plugin-react-swc": "3.7.2",
+    "react": "18.3.1",
     "jsdom": "^25.0.0",
-    "prettier": "^3.2.4",
     "vitest": "^2.0.0"
   }
 }

--- a/packages/router/vite.config.ts
+++ b/packages/router/vite.config.ts
@@ -2,7 +2,7 @@
 /// <reference types="vite/client" />
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackBuildConfig } from '@tanstack/config/build'
-import react from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react-swc'
 
 const config = defineConfig({
   plugins: [react()],

--- a/packages/tuono/package.json
+++ b/packages/tuono/package.json
@@ -114,11 +114,13 @@
     "web-streams-polyfill": "^4.0.0"
   },
   "devDependencies": {
+    "@tanstack/config": "0.7.13",
     "@types/babel-traverse": "^6.25.10",
     "@types/babel__traverse": "^7.20.6",
-    "@types/react": "^18.3.13",
-    "@types/react-dom": "^18.3.0",
-    "prettier": "^3.2.4",
+    "@types/react": "18.3.13",
+    "@types/react-dom": "18.3.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "vitest": "^2.0.0"
   },
   "sideEffects": false,

--- a/packages/tuono/vite.config.ts
+++ b/packages/tuono/vite.config.ts
@@ -2,7 +2,7 @@
 /// <reference types="vite/client" />
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackBuildConfig } from '@tanstack/config/build'
-import react from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react-swc'
 
 const config = defineConfig({
   plugins: [react()],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,26 +11,17 @@ importers:
       '@eslint/js':
         specifier: 9.15.0
         version: 9.15.0
-      '@tanstack/config':
-        specifier: ^0.7.0
-        version: 0.7.13(@types/node@22.10.0)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.6.3)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
       '@types/node':
-        specifier: ^22.0.0
+        specifier: 22.10.0
         version: 22.10.0
-      '@types/react':
-        specifier: ^18.3.13
-        version: 18.3.13
-      '@vitejs/plugin-react':
-        specifier: ^4.2.1
-        version: 4.3.4(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
       eslint:
-        specifier: ^9.15.0
+        specifier: 9.15.0
         version: 9.15.0
       eslint-import-resolver-typescript:
-        specifier: ^3.6.1
+        specifier: 3.6.3
         version: 3.6.3(@typescript-eslint/parser@8.15.0(eslint@9.15.0)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0)
       eslint-plugin-import:
-        specifier: ^2.31.0
+        specifier: 2.31.0
         version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0)
       eslint-plugin-react:
         specifier: 7.37.2
@@ -39,23 +30,17 @@ importers:
         specifier: 5.1.0
         version: 5.1.0(eslint@9.15.0)
       prettier:
-        specifier: ^3.2.4
+        specifier: 3.4.1
         version: 3.4.1
       turbo:
-        specifier: ^2.2.3
-        version: 2.3.3
+        specifier: 2.2.3
+        version: 2.2.3
       typescript:
         specifier: 5.6.3
         version: 5.6.3
       typescript-eslint:
         specifier: 8.15.0
         version: 8.15.0(eslint@9.15.0)(typescript@5.6.3)
-      vite:
-        specifier: ^5.2.11
-        version: 5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))
-      vitest:
-        specifier: ^2.0.0
-        version: 2.1.6(@types/node@22.10.0)(jsdom@25.0.1)(sugarss@4.0.1(postcss@8.4.49))
 
   apps/documentation:
     dependencies:
@@ -194,7 +179,7 @@ importers:
         version: 5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))
     devDependencies:
       '@tanstack/config':
-        specifier: ^0.7.11
+        specifier: 0.7.13
         version: 0.7.13(@types/node@22.10.0)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
       '@types/babel__core':
         specifier: ^7.20.5
@@ -216,7 +201,7 @@ importers:
         version: 5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))
     devDependencies:
       '@tanstack/config':
-        specifier: ^0.7.11
+        specifier: 0.7.13
         version: 0.7.13(@types/node@22.10.0)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
       '@types/babel__core':
         specifier: ^7.20.5
@@ -230,12 +215,6 @@ importers:
 
   packages/router:
     dependencies:
-      react:
-        specifier: '>=16.3.0'
-        version: 18.3.1
-      react-dom:
-        specifier: '>=16.3.0'
-        version: 18.3.1(react@18.3.1)
       react-intersection-observer:
         specifier: ^9.13.0
         version: 9.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -247,20 +226,26 @@ importers:
         version: 4.4.7(@types/react@18.3.13)(react@18.3.1)
     devDependencies:
       '@tanstack/config':
-        specifier: ^0.7.11
+        specifier: 0.7.13
         version: 0.7.13(@types/node@22.10.0)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
       '@testing-library/jest-dom':
         specifier: ^6.6.0
         version: 6.6.3
       '@testing-library/react':
         specifier: ^16.0.0
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: 18.3.13
+        version: 18.3.13
+      '@vitejs/plugin-react-swc':
+        specifier: 3.7.2
+        version: 3.7.2(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1
-      prettier:
-        specifier: ^3.2.4
-        version: 3.4.1
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
       vitest:
         specifier: ^2.0.0
         version: 2.1.6(@types/node@22.10.0)(jsdom@25.0.1)(sugarss@4.0.1(postcss@8.4.49))
@@ -309,12 +294,6 @@ importers:
       fast-text-encoding:
         specifier: ^1.0.6
         version: 1.0.6
-      react:
-        specifier: '>=16.3.0'
-        version: 18.3.1
-      react-dom:
-        specifier: '>=16.3.0'
-        version: 18.3.1(react@18.3.1)
       react-helmet-async:
         specifier: ^2.0.5
         version: 2.0.5(react@18.3.1)
@@ -334,6 +313,9 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
     devDependencies:
+      '@tanstack/config':
+        specifier: 0.7.13
+        version: 0.7.13(@types/node@22.10.0)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
       '@types/babel-traverse':
         specifier: ^6.25.10
         version: 6.25.10
@@ -341,14 +323,17 @@ importers:
         specifier: ^7.20.6
         version: 7.20.6
       '@types/react':
-        specifier: ^18.3.13
+        specifier: 18.3.13
         version: 18.3.13
       '@types/react-dom':
-        specifier: ^18.3.0
+        specifier: 18.3.0
         version: 18.3.0
-      prettier:
-        specifier: ^3.2.4
-        version: 3.4.1
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
       vitest:
         specifier: ^2.0.0
         version: 2.1.6(@types/node@22.10.0)(jsdom@25.0.1)(sugarss@4.0.1(postcss@8.4.49))
@@ -453,18 +438,6 @@ packages:
 
   '@babel/plugin-syntax-typescript@7.25.9':
     resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-self@7.25.9':
-    resolution: {integrity: sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.25.9':
-    resolution: {integrity: sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1115,9 +1088,6 @@ packages:
   '@types/react-dom@18.3.0':
     resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
 
-  '@types/react-dom@18.3.1':
-    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
-
   '@types/react@18.3.13':
     resolution: {integrity: sha512-ii/gswMmOievxAJed4PAHT949bpYjPKXvXo1v6cRB/kqc2ZR4n+SgyCyvyc5Fec5ez8VnUumI1Vk7j6fRyRogg==}
 
@@ -1196,12 +1166,6 @@ packages:
     resolution: {integrity: sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==}
     peerDependencies:
       vite: ^4 || ^5 || ^6
-
-  '@vitejs/plugin-react@4.3.4':
-    resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
   '@vitest/expect@2.1.6':
     resolution: {integrity: sha512-9M1UR9CAmrhJOMoSwVnPh2rELPKhYo0m/CSgqw9PyStpxtkwhmdM6XYlXGKeYyERY1N6EIuzkQ7e3Lm1WKCoUg==}
@@ -2766,10 +2730,6 @@ packages:
       react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
 
-  react-refresh@0.14.2:
-    resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
-    engines: {node: '>=0.10.0'}
-
   react-remove-scroll-bar@2.3.6:
     resolution: {integrity: sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==}
     engines: {node: '>=10'}
@@ -3174,38 +3134,38 @@ packages:
       react: '>=16.3.0'
       react-dom: '>=16.3.0'
 
-  turbo-darwin-64@2.3.3:
-    resolution: {integrity: sha512-bxX82xe6du/3rPmm4aCC5RdEilIN99VUld4HkFQuw+mvFg6darNBuQxyWSHZTtc25XgYjQrjsV05888w1grpaA==}
+  turbo-darwin-64@2.2.3:
+    resolution: {integrity: sha512-Rcm10CuMKQGcdIBS3R/9PMeuYnv6beYIHqfZFeKWVYEWH69sauj4INs83zKMTUiZJ3/hWGZ4jet9AOwhsssLyg==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.3.3:
-    resolution: {integrity: sha512-DYbQwa3NsAuWkCUYVzfOUBbSUBVQzH5HWUFy2Kgi3fGjIWVZOFk86ss+xsWu//rlEAfYwEmopigsPYSmW4X15A==}
+  turbo-darwin-arm64@2.2.3:
+    resolution: {integrity: sha512-+EIMHkuLFqUdJYsA3roj66t9+9IciCajgj+DVek+QezEdOJKcRxlvDOS2BUaeN8kEzVSsNiAGnoysFWYw4K0HA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.3.3:
-    resolution: {integrity: sha512-eHj9OIB0dFaP6BxB88jSuaCLsOQSYWBgmhy2ErCu6D2GG6xW3b6e2UWHl/1Ho9FsTg4uVgo4DB9wGsKa5erjUA==}
+  turbo-linux-64@2.2.3:
+    resolution: {integrity: sha512-UBhJCYnqtaeOBQLmLo8BAisWbc9v9daL9G8upLR+XGj6vuN/Nz6qUAhverN4Pyej1g4Nt1BhROnj6GLOPYyqxQ==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.3.3:
-    resolution: {integrity: sha512-NmDE/NjZoDj1UWBhMtOPmqFLEBKhzGS61KObfrDEbXvU3lekwHeoPvAMfcovzswzch+kN2DrtbNIlz+/rp8OCg==}
+  turbo-linux-arm64@2.2.3:
+    resolution: {integrity: sha512-hJYT9dN06XCQ3jBka/EWvvAETnHRs3xuO/rb5bESmDfG+d9yQjeTMlhRXKrr4eyIMt6cLDt1LBfyi+6CQ+VAwQ==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.3.3:
-    resolution: {integrity: sha512-O2+BS4QqjK3dOERscXqv7N2GXNcqHr9hXumkMxDj/oGx9oCatIwnnwx34UmzodloSnJpgSqjl8iRWiY65SmYoQ==}
+  turbo-windows-64@2.2.3:
+    resolution: {integrity: sha512-NPrjacrZypMBF31b4HE4ROg4P3nhMBPHKS5WTpMwf7wydZ8uvdEHpESVNMOtqhlp857zbnKYgP+yJF30H3N2dQ==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.3.3:
-    resolution: {integrity: sha512-dW4ZK1r6XLPNYLIKjC4o87HxYidtRRcBeo/hZ9Wng2XM/MqqYkAyzJXJGgRMsc0MMEN9z4+ZIfnSNBrA0b08ag==}
+  turbo-windows-arm64@2.2.3:
+    resolution: {integrity: sha512-fnNrYBCqn6zgKPKLHu4sOkihBI/+0oYFr075duRxqUZ+1aLWTAGfHZLgjVeLh3zR37CVzuerGIPWAEkNhkWEIw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.3.3:
-    resolution: {integrity: sha512-DUHWQAcC8BTiUZDRzAYGvpSpGLiaOQPfYXlCieQbwUvmml/LRGIe3raKdrOPOoiX0DYlzxs2nH6BoWJoZrj8hA==}
+  turbo@2.2.3:
+    resolution: {integrity: sha512-5lDvSqIxCYJ/BAd6rQGK/AzFRhBkbu4JHVMLmGh/hCb7U3CqSnr5Tjwfy9vc+/5wG2DJ6wttgAaA7MoCgvBKZQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -3713,16 +3673,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.0)':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.0)':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
@@ -4244,31 +4194,6 @@ snapshots:
 
   '@tabler/icons@3.22.0': {}
 
-  '@tanstack/config@0.7.13(@types/node@22.10.0)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.6.3)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))':
-    dependencies:
-      '@commitlint/parse': 19.5.0
-      commander: 12.1.0
-      current-git-branch: 1.1.0
-      esbuild-register: 3.6.0(esbuild@0.21.5)
-      interpret: 3.1.1
-      jsonfile: 6.1.0
-      liftoff: 5.0.0
-      minimist: 1.2.8
-      rollup-plugin-preserve-directives: 0.4.0(rollup@4.25.0)
-      semver: 7.6.3
-      simple-git: 3.27.0
-      v8flags: 4.0.1
-      vite-plugin-dts: 3.9.1(@types/node@22.10.0)(rollup@4.25.0)(typescript@5.6.3)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
-      vite-plugin-externalize-deps: 0.8.0(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
-      vite-tsconfig-paths: 4.3.2(typescript@5.6.3)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))
-    transitivePeerDependencies:
-      - '@types/node'
-      - esbuild
-      - rollup
-      - supports-color
-      - typescript
-      - vite
-
   '@tanstack/config@0.7.13(@types/node@22.10.0)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))':
     dependencies:
       '@commitlint/parse': 19.5.0
@@ -4315,7 +4240,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.0
       '@testing-library/dom': 10.4.0
@@ -4323,7 +4248,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.13
-      '@types/react-dom': 18.3.1
+      '@types/react-dom': 18.3.0
 
   '@types/acorn@4.0.6':
     dependencies:
@@ -4399,11 +4324,6 @@ snapshots:
   '@types/react-dom@18.3.0':
     dependencies:
       '@types/react': 18.3.13
-
-  '@types/react-dom@18.3.1':
-    dependencies:
-      '@types/react': 18.3.13
-    optional: true
 
   '@types/react@18.3.13':
     dependencies:
@@ -4505,17 +4425,6 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49)))':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.14.2
-      vite: 5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitest/expect@2.1.6':
     dependencies:
       '@vitest/spy': 2.1.6
@@ -4581,20 +4490,6 @@ snapshots:
     dependencies:
       '@vue/compiler-core': 3.5.12
       '@vue/shared': 3.5.12
-
-  '@vue/language-core@1.8.27(typescript@5.6.3)':
-    dependencies:
-      '@volar/language-core': 1.11.1
-      '@volar/source-map': 1.11.1
-      '@vue/compiler-dom': 3.5.12
-      '@vue/shared': 3.5.12
-      computeds: 0.0.1
-      minimatch: 9.0.5
-      muggle-string: 0.3.1
-      path-browserify: 1.0.1
-      vue-template-compiler: 2.7.16
-    optionalDependencies:
-      typescript: 5.6.3
 
   '@vue/language-core@1.8.27(typescript@5.7.2)':
     dependencies:
@@ -6504,8 +6399,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-refresh@0.14.2: {}
-
   react-remove-scroll-bar@2.3.6(@types/react@18.3.13)(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -6949,10 +6842,6 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  tsconfck@3.1.4(typescript@5.6.3):
-    optionalDependencies:
-      typescript: 5.6.3
-
   tsconfck@3.1.4(typescript@5.7.2):
     optionalDependencies:
       typescript: 5.7.2
@@ -7053,32 +6942,32 @@ snapshots:
       - supports-color
       - terser
 
-  turbo-darwin-64@2.3.3:
+  turbo-darwin-64@2.2.3:
     optional: true
 
-  turbo-darwin-arm64@2.3.3:
+  turbo-darwin-arm64@2.2.3:
     optional: true
 
-  turbo-linux-64@2.3.3:
+  turbo-linux-64@2.2.3:
     optional: true
 
-  turbo-linux-arm64@2.3.3:
+  turbo-linux-arm64@2.2.3:
     optional: true
 
-  turbo-windows-64@2.3.3:
+  turbo-windows-64@2.2.3:
     optional: true
 
-  turbo-windows-arm64@2.3.3:
+  turbo-windows-arm64@2.2.3:
     optional: true
 
-  turbo@2.3.3:
+  turbo@2.2.3:
     optionalDependencies:
-      turbo-darwin-64: 2.3.3
-      turbo-darwin-arm64: 2.3.3
-      turbo-linux-64: 2.3.3
-      turbo-linux-arm64: 2.3.3
-      turbo-windows-64: 2.3.3
-      turbo-windows-arm64: 2.3.3
+      turbo-darwin-64: 2.2.3
+      turbo-darwin-arm64: 2.2.3
+      turbo-linux-64: 2.2.3
+      turbo-linux-arm64: 2.2.3
+      turbo-windows-64: 2.2.3
+      turbo-windows-arm64: 2.2.3
 
   type-check@0.4.0:
     dependencies:
@@ -7268,23 +7157,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@3.9.1(@types/node@22.10.0)(rollup@4.25.0)(typescript@5.6.3)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))):
-    dependencies:
-      '@microsoft/api-extractor': 7.43.0(@types/node@22.10.0)
-      '@rollup/pluginutils': 5.1.3(rollup@4.25.0)
-      '@vue/language-core': 1.8.27(typescript@5.6.3)
-      debug: 4.3.7
-      kolorist: 1.8.0
-      magic-string: 0.30.14
-      typescript: 5.6.3
-      vue-tsc: 1.8.27(typescript@5.6.3)
-    optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))
-    transitivePeerDependencies:
-      - '@types/node'
-      - rollup
-      - supports-color
-
   vite-plugin-dts@3.9.1(@types/node@22.10.0)(rollup@4.25.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@22.10.0)
@@ -7305,17 +7177,6 @@ snapshots:
   vite-plugin-externalize-deps@0.8.0(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))):
     dependencies:
       vite: 5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))
-
-  vite-tsconfig-paths@4.3.2(typescript@5.6.3)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))):
-    dependencies:
-      debug: 4.3.7
-      globrex: 0.1.2
-      tsconfck: 3.1.4(typescript@5.6.3)
-    optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite-tsconfig-paths@4.3.2(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0)(sugarss@4.0.1(postcss@8.4.49))):
     dependencies:
@@ -7378,13 +7239,6 @@ snapshots:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
-
-  vue-tsc@1.8.27(typescript@5.6.3):
-    dependencies:
-      '@volar/typescript': 1.11.1
-      '@vue/language-core': 1.8.27(typescript@5.6.3)
-      semver: 7.6.3
-      typescript: 5.6.3
 
   vue-tsc@1.8.27(typescript@5.7.2):
     dependencies:


### PR DESCRIPTION
## Context & Description

Close #244.

Consistently use `@vitejs/plugin-react-swc` across all npm packages build.

I also consolidated all dependencies across all npm packages:
- all modified `devDependencies` has a fixed version range to know easily which version is actually used
- removed `@types/react` from the root `package.json`. Since we are planning to make `tuono` framework agnostic in the future I added `react` and `@types/react` to each package.

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->
