### PR TITLE
feat(packages/vite-plugins): use named export and consistent names across plugins

### DIFF
--- a/packages/tuono-fs-router-vite-plugin/src/index.ts
+++ b/packages/tuono-fs-router-vite-plugin/src/index.ts
@@ -8,7 +8,7 @@ const ROUTES_DIRECTORY_PATH = './src/routes'
 
 let lock = false
 
-export default function RouterGenerator(): Plugin {
+export function TuonoFsRouterPlugin(): Plugin {
   const generate = async (): Promise<void> => {
     if (lock) return
     lock = true

--- a/packages/tuono-lazy-fn-vite-plugin/src/index.ts
+++ b/packages/tuono-lazy-fn-vite-plugin/src/index.ts
@@ -119,12 +119,12 @@ const TurnLazyIntoStaticImport: BabelPluginItem = {
   },
 }
 
-interface LazyLoadingPluginOptions {
+interface TuonoLazyFnPluginOptions {
   include: FilterPattern
 }
 
-export function LazyLoadingPlugin(
-  options: LazyLoadingPluginOptions,
+export function TuonoLazyFnPlugin(
+  options: TuonoLazyFnPluginOptions,
 ): VitePlugin {
   const { include } = options
 

--- a/packages/tuono-lazy-fn-vite-plugin/tests/transpileSource.test.ts
+++ b/packages/tuono-lazy-fn-vite-plugin/tests/transpileSource.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import { it, expect, describe } from 'vitest'
 import type { Plugin } from 'vite'
 
-import { LazyLoadingPlugin } from '../src'
+import { TuonoLazyFnPlugin } from '../src'
 
 type ViteTransformHandler = Exclude<
   Plugin['transform'],
@@ -17,7 +17,7 @@ function getTransform(): (...args: Parameters<ViteTransformHandler>) => string {
   /** @warning Keep in sync with {@link createBaseViteConfigFromTuonoConfig} */
   const pluginFilesInclude = /\.(jsx|js|mdx|md|tsx|ts)$/
 
-  return LazyLoadingPlugin({ include: pluginFilesInclude }).transform as never
+  return TuonoLazyFnPlugin({ include: pluginFilesInclude }).transform as never
 }
 
 describe('"dynamic" sources', async () => {

--- a/packages/tuono/src/build/index.ts
+++ b/packages/tuono/src/build/index.ts
@@ -2,8 +2,8 @@ import type { InlineConfig, Plugin } from 'vite'
 import { build, createServer, mergeConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import inject from '@rollup/plugin-inject'
-import ViteFsRouter from 'tuono-fs-router-vite-plugin'
-import { LazyLoadingPlugin } from 'tuono-lazy-fn-vite-plugin'
+import { TuonoFsRouterPlugin } from 'tuono-fs-router-vite-plugin'
+import { TuonoLazyFnPlugin } from 'tuono-lazy-fn-vite-plugin'
 
 import type { TuonoConfig } from '../config'
 
@@ -66,8 +66,8 @@ function createBaseViteConfigFromTuonoConfig(
       // @ts-expect-error see above comment
       react({ include: pluginFilesInclude }),
 
-      ViteFsRouter(),
-      LazyLoadingPlugin({ include: pluginFilesInclude }),
+      TuonoFsRouterPlugin(),
+      TuonoLazyFnPlugin({ include: pluginFilesInclude }),
     ],
   }
 


### PR DESCRIPTION
## Context & Description

Close #234.

All vite plugins now have consistent names and they are made available via a named export.



