### PR TITLE
chore: refine `eslint` ignores and fix format script of `tuono-fs-router-vite-plugin`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,6 @@ pnpm-lock.yaml
 dist
 .tuono
 
+vite.config.ts.timestamp-*
+
 packages/tuono-lazy-fn-vite-plugin/tests/sources/*

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,16 +11,20 @@ export default tseslint.config(
     ignores: [
       // #region shared
       '**/dist',
+      '**/out',
       '**/.tuono',
       '**/vite.config.ts.timestamp**',
       // #endregion shared
 
       // #region package-specific
       'packages/tuono-fs-router-vite-plugin/tests/generator/**',
+
       'packages/tuono-lazy-fn-vite-plugin/tests/sources/**',
 
       'packages/tuono/bin/**',
       // #endregion package-specific
+
+      'examples/**',
     ],
   },
   {

--- a/packages/tuono-fs-router-vite-plugin/.prettierignore
+++ b/packages/tuono-fs-router-vite-plugin/.prettierignore
@@ -1,2 +1,0 @@
-dist
-pnpm-lock.yaml

--- a/packages/tuono-fs-router-vite-plugin/package.json
+++ b/packages/tuono-fs-router-vite-plugin/package.json
@@ -7,8 +7,8 @@
     "dev": "vite build --watch",
     "build": "vite build",
     "lint": "eslint .",
-    "format": "prettier -u --write --ignore-unknown '**/*'",
-    "format:check": "prettier --check --ignore-unknown '**/*'",
+    "format": "prettier --write --ignore-unknown --ignore-path ../../.prettierignore .",
+    "format:check": "prettier --check --ignore-unknown --ignore-path ../../.prettierignore .",
     "types": "tsc --noEmit",
     "test:watch": "vitest",
     "test": "vitest run"


### PR DESCRIPTION
## Context & Description

Avoid to run `eslint` on the following folders:
- `out` - `tuono build` output folder
- `examples/*` workspaces, there is no script, not CI task that checks linting for those folder.
   We might want to change this in the future.

---

Fix format related scripts on `tuono-fs-router-vite-plugin`