### PR TITLE
chore: dockerization of the tuono repo!

### DIFF
--- a/.github/workflows/repo-root-ci.yml
+++ b/.github/workflows/repo-root-ci.yml
@@ -9,12 +9,14 @@ on:
     branches:
       - 'main'
     paths:
-      - '.github/**'
       - '*'
+      - '.github/**'
+      - '.docker/**'
   pull_request:
     paths:
-      - '.github/**'
       - '*'
+      - '.github/**'
+      - '.docker/**'
 
 jobs:
   build-and-test:

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -30,9 +30,9 @@ git clone https://github.com/<your-name-here>/tuono
 cd tuono
 ```
 
-For the next steps, you can either set up the environment directly on your computer or use a ready-to-use Docker image (go to [Use Docker](#use-docker) part).
+For the next steps, you can either set up the environment directly on your computer or use a ready-to-use Docker image (go to the [Docker setup](#docker-setup) part).
 
-### Set up your computer directly
+### Local setup
 
 #### Rust tool chain
 
@@ -69,7 +69,7 @@ pnpm run check-all
 cargo build
 ```
 
-### Use Docker
+### Docker setup
 
 #### Introduction
 
@@ -79,14 +79,14 @@ Some IDEs (such as vscode with the [Dev Containers extension](https://marketplac
 
 **Before proceeding with this guide, make sure that the `node_modules` and `target` directories are either absent or empty in the subprojects of Tuono from your host machine where you want to contribute.** This ensures a clean and consistent environment when using Docker.
 
-#### Build the Docker Container for Tuono
+#### Build the Tuono's Docker Container
 
 First, ensure Docker is installed on your machine by following the instructions on the [Docker official site](https://docs.docker.com/engine/install/).
 
 Once Docker is installed, use the following command to build the image into a container named tuono-source-container:
 
 ```sh
-# Note: Execute this command at the project root
+# Note: Execute this command in the project root
 docker compose -f docker/compose.yml up --build -d
 ```
 
@@ -96,13 +96,13 @@ To verify that everything is working as expected, run the following command:
 docker images && docker ps -a --size
 ```
 
-Or on Windows :
+Or on Windows:
 
 ```powershell
 docker images; docker ps -a --size
 ```
 
-You should see the image named tuono-source-image and the container tuono-source-container. The container's status should be "Up".
+You should see the image named tuono-source-image and the container tuono-source-container. The container's status should be "up".
 
 Use the following command to connect to the container:
 

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -73,9 +73,9 @@ cargo build
 
 #### Introduction
 
-Docker takes care of configuring the development environment, so you don’t need to worry about installing specific versions of packages like Node.js or pnpm. The Docker image handles this for you! 
+Docker takes care of configuring the development environment, so you don’t need to worry about installing specific versions of packages like Node.js or pnpm. The Docker image handles this for you!
 Using Docker, **the only operations you’ll need to manage on your host machine are related to git**. (don't use phpnm, cargo, ... from your host machine)
-Some IDEs (such as vscode with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)) allow you to connect directly to the Docker container. 
+Some IDEs (such as vscode with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)) allow you to connect directly to the Docker container.
 
 **Before proceeding with this guide, make sure that the `node_modules` and `target` directories are either absent or empty in the subprojects of Tuono from your host machine where you want to contribute.** This ensures a clean and consistent environment when using Docker.
 

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -30,12 +30,16 @@ git clone https://github.com/<your-name-here>/tuono
 cd tuono
 ```
 
-### Rust tool chain
+For the next steps, you can either set up the environment directly on your computer or use a ready-to-use Docker image (go to [Use Docker](#use-docker) part).
+
+### Set up your computer directly
+
+#### Rust tool chain
 
 Install the Rust programming language tool chain (`rust` and `cargo`).
 Follows instructions in the official [docs](https://rustup.rs/)
 
-### Node.js — runtime
+#### Node.js — runtime
 
 Install `Node.js`.
 You can follow the instructions from the [Node official site](https://nodejs.org/en/download/package-manager)
@@ -50,19 +54,58 @@ You can follow the instructions from the [Node official site](https://nodejs.org
 >
 > to simply pick up the correct version!
 
-### Node.js — package manager
+#### Node.js — package manager
 
 We use [`pnpm`](https://pnpm.io) as Node.js package manager.
 
 You can see which version of yarn we use by checking the `packageManager` field in the root `package.json`.
 
-### Pre-flight checks
+#### Pre-flight checks
 
 To check that everything is working properly, run:
 
 ```sh
 pnpm run check-all
 cargo build
+```
+
+### Use Docker
+
+#### Introduction
+
+Docker takes care of configuring the development environment, so you don’t need to worry about installing specific versions of packages like Node.js or pnpm. The Docker image handles this for you!
+Using Docker, the only operations you’ll need to manage on your host machine are related to git.
+Some IDEs (such as vscode with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)) allow you to connect directly to the Docker container.
+
+#### Build the Docker Container for Tuono
+
+First, ensure Docker is installed on your machine by following the instructions on the [Docker official site](https://docs.docker.com/engine/install/).
+
+Once Docker is installed, use the following command to build the image into a container named tuono-source-container:
+
+```sh
+# Note: Execute this command at the project root
+docker compose -f docker/compose.yml up --build -d
+```
+
+To verify that everything is working as expected, run the following command:
+
+```sh
+docker images && docker ps -a --size
+```
+
+Or on Windows :
+
+```powershell
+docker images; docker ps -a --size
+```
+
+You should see the image named tuono-source-image and the container tuono-source-container. The container's status should be "Up".
+
+Use the following command to connect to the container:
+
+```sh
+docker exec -it tuono-source-container /bin/bash
 ```
 
 ## Tuono development

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -73,9 +73,11 @@ cargo build
 
 #### Introduction
 
-Docker takes care of configuring the development environment, so you don’t need to worry about installing specific versions of packages like Node.js or pnpm. The Docker image handles this for you!
-Using Docker, the only operations you’ll need to manage on your host machine are related to git.
-Some IDEs (such as vscode with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)) allow you to connect directly to the Docker container.
+Docker takes care of configuring the development environment, so you don’t need to worry about installing specific versions of packages like Node.js or pnpm. The Docker image handles this for you! 
+Using Docker, **the only operations you’ll need to manage on your host machine are related to git**. (don't use phpnm, cargo, ... from your host machine)
+Some IDEs (such as vscode with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)) allow you to connect directly to the Docker container. 
+
+**Before proceeding with this guide, make sure that the `node_modules` and `target` directories are either absent or empty in the subprojects of Tuono from your host machine where you want to contribute.** This ensures a clean and consistent environment when using Docker.
 
 #### Build the Docker Container for Tuono
 

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,19 @@
+# project
+node_modules
+.pnpm-store
+target
+.turbo
+
+# git
+.git
+.gitignore
+
+# docker
+docker/compose.yml
+docker/Dockerfile
+docker/.dockerignore
+
+# IDE
+.vscode
+.idea
+*.iml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,5 +46,5 @@ RUN ["pnpm", "install", "--frozen-lockfile"]
 
 ## Compile and add the directory with compiled binaries to the PATH for direct access
 
-RUN ["cargo", "build", "--frozen-lockfile"]
+RUN ["cargo", "build"]
 ENV PATH=/tuono/target/debug:$PATH

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,42 +1,50 @@
-# Use the specified Rust version and base OS as the base image
+# ARGs obtained from the compose.yml file
+
 ARG BASE_OS
 ARG RUST_VERSION
+
 FROM rust:${RUST_VERSION}-${BASE_OS}
 
 # Nodejs installation
-RUN ["mkdir", "/usr/local/nvm"]
-ENV NVM_DIR /usr/local/nvm
 
-RUN ["apt", "update"]
-RUN ["apt", "install", "curl", "-y", "--no-install-recommends"]
+RUN ["mkdir", "/usr/local/node"]
+WORKDIR /usr/local/node
 
-RUN ["curl", "https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh", "-o", "/tmp/install_nvm.sh"]
-RUN ["bash", "/tmp/install_nvm.sh"]
+## Retrieves the targeted version of Node in the container
 
-ARG NODE_VERSION
-RUN ["sh", "-c", ". /usr/local/nvm/nvm.sh && nvm install ${NODE_VERSION}"]
+COPY .nvmrc /tmp/.nvmrc
 
-# Ensure Node.js binaries are available in the PATH
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+## Download the Node.js standelone binary archive && extract it && clean files
 
-# Install pnpm
+RUN ["/bin/sh", "-c", "NODE_VERSION=$(cat /tmp/.nvmrc) && \
+    wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && \
+    tar xf node-v${NODE_VERSION}-linux-x64.tar.xz --strip-components 1 && \
+    rm node-v${NODE_VERSION}-linux-x64.tar.xz /tmp/.nvmrc"]
+
+## Ensure Node.js binaries are available in the PATH
+
+ENV PATH /usr/local/node/bin:$PATH
+
+# pnpm installation
+
 RUN ["npm", "install", "-g", "pnpm"]
-RUN ["mkdir", "/pnpm"]
-ENV PATH=/pnpm:$PATH
-ENV PNPM_HOME=/pnpm
 
-# Install cargo-watch for Rust live-reloading
+# cargo-watch installation (for Rust live-reloading during dev')
+
 RUN ["cargo", "install", "cargo-watch"]
 
-# Set the working directory to /tuono
-WORKDIR /tuono
+# global configuration done ! let's focus on the project itself
 
-# Copy project files into the container (excepted files/dir declared in .dockerignore)
+## Copy project files into the container (excepted files/dir declared in .dockerignore) to /tuono directory
+
+WORKDIR /tuono
 COPY . .
 
-# Install Node.js dependencies (defined in package.json)
+## Install Node.js dependencies (defined in package.json)
+
 RUN ["pnpm", "install"]
 
-# Compile and add the directory with compiled binaries to the PATH for direct access
+## Compile and add the directory with compiled binaries to the PATH for direct access
+
 RUN ["cargo", "build"]
 ENV PATH=/tuono/target/debug:$PATH

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,12 +19,11 @@ RUN ["sh", "-c", ". /usr/local/nvm/nvm.sh && nvm install ${NODE_VERSION}"]
 # Ensure Node.js binaries are available in the PATH
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-# Install pnpm and turbo globally
+# Install pnpm
 RUN ["npm", "install", "-g", "pnpm"]
 RUN ["mkdir", "/pnpm"]
 ENV PATH=/pnpm:$PATH
 ENV PNPM_HOME=/pnpm
-RUN ["pnpm", "install", "-g", "turbo"]
 
 # Install cargo-watch for Rust live-reloading
 RUN ["cargo", "install", "cargo-watch"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,10 +25,6 @@ RUN ["/bin/sh", "-c", "NODE_VERSION=$(cat /tmp/.nvmrc) && \
 
 ENV PATH /usr/local/node/bin:$PATH
 
-# pnpm installation
-
-RUN ["npm", "install", "-g", "pnpm"]
-
 # cargo-watch installation (for Rust live-reloading during dev')
 
 RUN ["cargo", "install", "cargo-watch"]
@@ -39,6 +35,11 @@ RUN ["cargo", "install", "cargo-watch"]
 
 WORKDIR /tuono
 COPY . .
+
+# pnpm installation based on version found in package.json
+
+RUN ["corepack", "enable"]
+RUN ["corepack", "install"]
 
 ## Install Node.js dependencies (defined in package.json)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,43 @@
+# Use the specified Rust version and base OS as the base image
+ARG BASE_OS
+ARG RUST_VERSION
+FROM rust:${RUST_VERSION}-${BASE_OS}
+
+# Nodejs installation
+RUN ["mkdir", "/usr/local/nvm"]
+ENV NVM_DIR /usr/local/nvm
+
+RUN ["apt", "update"]
+RUN ["apt", "install", "curl", "-y", "--no-install-recommends"]
+
+RUN ["curl", "https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh", "-o", "/tmp/install_nvm.sh"]
+RUN ["bash", "/tmp/install_nvm.sh"]
+
+ARG NODE_VERSION
+RUN ["sh", "-c", ". /usr/local/nvm/nvm.sh && nvm install ${NODE_VERSION}"]
+
+# Ensure Node.js binaries are available in the PATH
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# Install pnpm and turbo globally
+RUN ["npm", "install", "-g", "pnpm"]
+RUN ["mkdir", "/pnpm"]
+ENV PATH=/pnpm:$PATH
+ENV PNPM_HOME=/pnpm
+RUN ["pnpm", "install", "-g", "turbo"]
+
+# Install cargo-watch for Rust live-reloading
+RUN ["cargo", "install", "cargo-watch"]
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy project files into the container (excepted files/dir declared in .dockerignore)
+COPY . .
+
+# Install Node.js dependencies (defined in package.json)
+RUN ["pnpm", "install"]
+
+# Compile and add the directory with compiled binaries to the PATH for direct access
+RUN ["cargo", "build"]
+ENV PATH=/app/target/debug:$PATH

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,9 +42,9 @@ COPY . .
 
 ## Install Node.js dependencies (defined in package.json)
 
-RUN ["pnpm", "install"]
+RUN ["pnpm", "install", "--frozen-lockfile"]
 
 ## Compile and add the directory with compiled binaries to the PATH for direct access
 
-RUN ["cargo", "build"]
+RUN ["cargo", "build", "--frozen-lockfile"]
 ENV PATH=/tuono/target/debug:$PATH

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,8 +29,8 @@ RUN ["pnpm", "install", "-g", "turbo"]
 # Install cargo-watch for Rust live-reloading
 RUN ["cargo", "install", "cargo-watch"]
 
-# Set the working directory to /app
-WORKDIR /app
+# Set the working directory to /tuono
+WORKDIR /tuono
 
 # Copy project files into the container (excepted files/dir declared in .dockerignore)
 COPY . .
@@ -40,4 +40,4 @@ RUN ["pnpm", "install"]
 
 # Compile and add the directory with compiled binaries to the PATH for direct access
 RUN ["cargo", "build"]
-ENV PATH=/app/target/debug:$PATH
+ENV PATH=/tuono/target/debug:$PATH

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # ARGs obtained from the compose.yml file
 
-ARG BASE_OS
-ARG RUST_VERSION
+ARG BASE_OS=bookworm
+ARG RUST_VERSION=1.83
 
 FROM rust:${RUST_VERSION}-${BASE_OS}
 

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -8,14 +8,15 @@ services:
       args:
         RUST_VERSION: 1.83
         BASE_OS: bookworm
-        NODE_VERSION: 22.11.0
     image: tuono-source-image
     ports:
       - "3000:3000" # for apps/documentation frontend app
-    volumes: # mount the project into a volume but node_modules / .pnpm-store / target / .turbo directories won't by sync from container to host
+    volumes: # mount the project into a volume but node_modules / .pnpm-store / target / ... directories won't by sync from container to host
       - ..:/tuono
       - /tuono/node_modules
       - /tuono/.pnpm-store
       - /tuono/target
       - /tuono/.turbo
+      - /tuono/apps/documentation/node_modules
+      - /tuono/apps/documentation/target
     tty: true

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -14,9 +14,9 @@ services:
       - "3000:3000" # frontend 
       - "3001:3001" # backend
     volumes: # mount the project into a volume but node_modules / .pnpm-store / target / .turbo directories won't by sync from container to host
-      - ..:/app
-      - /app/node_modules
-      - /app/.pnpm-store
-      - /app/target
-      - /app/.turbo
+      - ..:/tuono
+      - /tuono/node_modules
+      - /tuono/.pnpm-store
+      - /tuono/target
+      - /tuono/.turbo
     tty: true

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -11,8 +11,7 @@ services:
         NODE_VERSION: 22.11.0
     image: tuono-source-image
     ports:
-      - "3000:3000" # frontend 
-      - "3001:3001" # backend
+      - "3000:3000" # for apps/documentation frontend app
     volumes: # mount the project into a volume but node_modules / .pnpm-store / target / .turbo directories won't by sync from container to host
       - ..:/tuono
       - /tuono/node_modules

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -14,9 +14,15 @@ services:
     volumes: # mount the project into a volume but node_modules / .pnpm-store / target / ... directories won't by sync from container to host
       - ..:/tuono
       - /tuono/node_modules
-      - /tuono/.pnpm-store
       - /tuono/target
+      - /tuono/.pnpm-store
       - /tuono/.turbo
       - /tuono/apps/documentation/node_modules
       - /tuono/apps/documentation/target
+      - /tuono/examples/tuono-app/node_modules
+      - /tuono/examples/tuono-app/target
+      - /tuono/examples/tuono-tutorial/node_modules
+      - /tuono/examples/tuono-tutorial/target
+      - /tuono/examples/with-mdx/node_modules
+      - /tuono/examples/with-mdx/target
     tty: true

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,13 +1,14 @@
 services:
   tuono:
+    platform: "linux/amd64"
     container_name: tuono-source-container
     hostname: tuono-source-container
     build:
       context: ../
       dockerfile: ./docker/Dockerfile
       args:
-        RUST_VERSION: 1.83
-        BASE_OS: bookworm
+        RUST_VERSION: 1.83 # if change, think to update the default ARGs in Dockerfile
+        BASE_OS: bookworm # if change, think to update the default ARGs in Dockerfile
     image: tuono-source-image
     ports:
       - '3000:3000' # expose default port used by tuono server

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,6 +1,6 @@
 services:
   tuono:
-    platform: "linux/amd64"
+    platform: linux/amd64
     container_name: tuono-source-container
     hostname: tuono-source-container
     build:

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -10,7 +10,7 @@ services:
         BASE_OS: bookworm
     image: tuono-source-image
     ports:
-      - "3000:3000" # expose default port used by tuono server
+      - '3000:3000' # expose default port used by tuono server
     volumes: # mount the project into a volume but node_modules / .pnpm-store / target / ... directories won't by sync from container to host
       - ..:/tuono
       - /tuono/node_modules

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -10,7 +10,7 @@ services:
         BASE_OS: bookworm
     image: tuono-source-image
     ports:
-      - "3000:3000" # for apps/documentation frontend app
+      - "3000:3000" # expose default port used by tuono server
     volumes: # mount the project into a volume but node_modules / .pnpm-store / target / ... directories won't by sync from container to host
       - ..:/tuono
       - /tuono/node_modules

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,22 @@
+services:
+  tuono:
+    container_name: tuono-source-container
+    hostname: tuono-source-container
+    build:
+      context: ../
+      dockerfile: ./docker/Dockerfile
+      args:
+        RUST_VERSION: 1.83
+        BASE_OS: bookworm
+        NODE_VERSION: 22.11.0
+    image: tuono-source-image
+    ports:
+      - "3000:3000" # frontend 
+      - "3001:3001" # backend
+    volumes: # mount the project into a volume but node_modules / .pnpm-store / target / .turbo directories won't by sync from container to host
+      - ..:/app
+      - /app/node_modules
+      - /app/.pnpm-store
+      - /app/target
+      - /app/.turbo
+    tty: true


### PR DESCRIPTION
## Context & Description

I have dockerized the repo to simplify local development on the source code (one environment to rule them all!). To determine which packages to install and their order, I relied on the ['local development' documentation](https://tuono.dev/documentation/contributing/local-development).

Everything has been isolated in a dedicated docker folder (to avoid adding extra configuration files at the root of the project).

Currently, packages such as `pnpm`, `turbo`, and `cargo` are properly installed, and tuono (seems) compiles correctly. I noticed that the Node version is currently managed via the `/.nvmrc` file. To streamline the build process (and centralize versioning) with Docker, I have transferred this version into the `docker/compose.yml` file.

## How to use Docker (with this current work)

Firstly, install docker and docker compose. 
Then navigate to the root of the project using your terminal, then...

- Build the Docker container : `docker compose -f docker/compose.yml up --build -d`
- List active images and containers : `docker images && docker ps -a --size`
- Connect to the container : `docker exec -it tuono-source-container /bin/bash`
- (bonus) Delete all Docker images/containers/volumes + caches (caution here!) : 

```bash
docker ps -q | \
xargs -r docker stop && docker ps -aq | \
xargs -r docker rm -v && docker network prune -f && docker system prune -af --volumes && docker images -q | \
xargs -r docker rmi
```

The docker container's responsability is to handle all the project environment. That's mean you have only to just install your prefered IDE (like vscode by example), connect it to the docker container and the dev can begin ! The code source is sync between container and host ; at the end, you can git add/commit/push/... from your host machine.

## To do 

- I can't run the web server for the documentation website  (the `tuono dev` command seems work well, but a `curl http://127.0.0.1:3000` from container failed). I haven't found how to fix this problem yet..
- The command `turbo check-all` does not work (turbo error : could not find task check-all in project). I have to run directly `turbo build lint format:check types --filter='!./examples'`
- Since I don't know the Turbo tool very well, I haven't delved too deeply into it with Docker yet. I assume there's some work to be done on that front


Once the work with Docker is complete, I can suggest updating the documentation to summarize how to use it, if you'd like :)