### PR TITLE
docs(local-development): use `pnpm` instead of `turbo`

### DIFF
--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -61,7 +61,7 @@ You can see which version of yarn we use by checking the `packageManager` field 
 To check that everything is working properly, run:
 
 ```sh
-turbo run check-all
+pnpm run check-all
 cargo build
 ```
 
@@ -70,7 +70,7 @@ cargo build
 1. Start tuono frontend build using
 
    ```sh
-   turbo run dev
+   pnpm run dev
    ```
 
 2. In another terminal run


### PR DESCRIPTION
## Context & Description

Related to https://github.com/tuono-labs/tuono/pull/276#pullrequestreview-2526914077

Script in "Local development" where incorrectly using `turbo`. 
They should use `pnpm` (which run the relevant script using `turbo`)
