### PR TITLE
chore(renovate): setup a package rule for eslint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "ignorePaths": ["**/benches/**"],
-  "schedule": ["every 2 weeks on monday"]
+  "schedule": ["every 2 weeks on monday"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchPackageNames": [
+        "eslint",
+        "eslint-*",
+        "typescript-eslint",
+        "@eslint/**"
+      ],
+      "groupName": "devDependencies (eslint)"
+    }
+  ]
 }


### PR DESCRIPTION
## Context & Description

Having a single PR for each dependency might be a pain when we have to update.
Using [packageRules](https://docs.renovatebot.com/configuration-options/#packagerules)  should help mitigate this problem.

At the moment I only a group for `eslint` related packages. 
Do you have any idea for additional groups?
