### PR TITLE
docs(configuration): fill page content

### DIFF
--- a/apps/documentation/src/components/mdx-provider/mdx-bold/mdx-bold.tsx
+++ b/apps/documentation/src/components/mdx-provider/mdx-bold/mdx-bold.tsx
@@ -2,5 +2,5 @@ import type { JSX } from 'react'
 import { Text, type TextProps } from '@mantine/core'
 
 export default function MdxBold(props: TextProps): JSX.Element {
-  return <Text fw={700} {...props} />
+  return <Text component="span" fw={700} {...props} />
 }

--- a/apps/documentation/src/components/sidebar/config.ts
+++ b/apps/documentation/src/components/sidebar/config.ts
@@ -239,7 +239,7 @@ export const sidebarElements: Array<SidebarElement> = [
   },
   {
     type: 'element',
-    label: 'tuono.config.ts',
+    label: 'Configuration',
     href: '/documentation/configuration',
   },
 

--- a/apps/documentation/src/routes/documentation/configuration.mdx
+++ b/apps/documentation/src/routes/documentation/configuration.mdx
@@ -11,4 +11,142 @@ import Breadcrumbs, { Element } from '@/components/breadcrumbs'
 
 # Configuration
 
-TODO
+`tuono.config.ts` is a configuration file used in Tuono framework to customize aspects of the 
+build process and development environment. Tuono leverages `Vite` - which is a modern, 
+fast build tool and development server for web applications.
+
+The `TuonoConfig` interface serves as a wrapper for `vite.config.ts` -
+
+```typescript
+// ->> node_modules/tuono/dist/esm/config/types.d.ts
+export interface TuonoConfig {
+    vite?: {
+        alias?: AliasOptions;
+        optimizeDeps?: DepOptimizationOptions;
+        plugins?: Array<Plugin>;
+    };
+}
+```
+
+As of the current version, it supports the following properties 
+
+- `alias`: Useful for configuring custom source alias paths during imports, similar to `Next.js`. [ 👉 Read more here](https://vite.dev/config/shared-options)
+- `optimizeDeps`: Vite's dependency optimizer used only during dev. [ 👉 Read more here](https://vite.dev/config/dep-optimization-options)
+- `plugins`:  Useful for extending vite's functionality. [ 👉 Read more here](https://vite.dev/guide/using-plugins)
+
+We will cover one of the properties `alias` here in detail
+
+## 1. Configure Path Alias in Tuono
+
+After configuring aliases, you can use them in your imports (very similar to `Next.js` framework):
+
+```typescript
+// Instead of
+import MyComponent from '../../../components/MyComponent'; // relative to src folder
+
+// You can use
+import MyComponent from '@/components/MyComponent'; // considers 'src' as baseFolder
+```
+
+To achieve this, you need to add the following configuration to your `tuono.config.ts`
+
+```typescript
+// ->> tuono.config.ts
+import type { TuonoConfig } from "tuono/config";
+import path, { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function getDirname(importMetaUrl: string): string {
+  return dirname(fileURLToPath(importMetaUrl));
+}
+
+const __dirname = getDirname(import.meta.url);
+
+const config: TuonoConfig = {
+  vite: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+    
+  },
+};
+
+export default config;
+```
+
+As Tuono uses Typescript, you should also update `compilerOptions` under `tsconfig.json` file to include these aliases for proper type checking
+
+> *NOTE: please add the following code-snippet under `compilerOptions` and not replace `tsconfig.json`*
+
+```json
+/* ->> tsconfig.json*/
+{
+  "compilerOptions": {
+    ...
+    /* src alias "@" configuration */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ]
+    },
+    ...
+  }
+}
+```
+
+One last thing is to add `@types/node` to your project, so Typescript stops complaining during file inputs.
+
+```bash
+# add @types/node to your project
+npm i -D @types/node
+```
+
+
+With these you're good to go! ✨
+
+## Practical Usecases
+
+### 01. Design libraries - ShadCN
+
+You can use libraries like `ShadCN` along with Tuono with this feature. Just follow their instruction on `Vite` site  upto `Step 03`. [👉 Link provided here](https://ui.shadcn.com/docs/installation/vite)
+
+### 02. More Path Aliases
+
+You can even keep extending aliases to `@components` or `@services` by just adding them to `tuono.config.ts` like so -
+
+```typescript
+// ->> tuono.config.ts
+// NOTE: 💡 THIS IS COMPLETELY OPTIONAL
+import type { TuonoConfig } from "tuono/config";
+import path, { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function getDirname(importMetaUrl: string): string {
+  return dirname(fileURLToPath(importMetaUrl));
+}
+
+const __dirname = getDirname(import.meta.url);
+
+const config: TuonoConfig = {
+  vite: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      // NOTE: 💡 only works if you have a 'components' & 'services' folder under 'src'
+      // NOTE: 💡 similarly, you need to also configure tsconfig.json
+      '@components': path.resolve(__dirname, './src/components'), // ..optional
+      '@services': path.resolve(__dirname, './src/services'), // ..optional
+    },
+    
+  },
+};
+
+export default config;
+
+
+```
+
+---
+
+
+

--- a/apps/documentation/src/routes/documentation/configuration.mdx
+++ b/apps/documentation/src/routes/documentation/configuration.mdx
@@ -11,102 +11,39 @@ import Breadcrumbs, { Element } from '@/components/breadcrumbs'
 
 # Configuration
 
-`tuono.config.ts` is a configuration file used in Tuono framework to customize aspects of the 
-build process and development environment. The config file is written in typescript, so you can rely on type-check and autosuggestion provided by the `TuonoConfig` type,
-which is exported by `tuono/config`.
+Tuono can be configured using the `tuono.config.ts` file,
+which allows you to customize various aspects of the build process and development environment.
+
+The config file is written in TypeScript,
+so you can take advantage of type checking and auto-suggestions provided by the `TuonoConfig` type,
+which is exported from `tuono/config`.
 
 ```ts
-import type { TuonoConfig } from 'tuono/config';
+import type { TuonoConfig } from 'tuono/config'
 
-const config: TuonoConfig = { /* typesafe config */ }
+const config: TuonoConfig = {
+  /* typesafe config */
+}
 
 export default config
 ```
 
-## Vite
+## vite
 
-Tuono leverages `Vite` - which is a modern, fast build tool and development server for web applications. The config file `tuono.config.ts` supports the following properties of vite -
+Tuono leverages Vite, a modern and fast build tool and development server for web applications.
 
-### Vite.alias
+As a result, **some** Vite configuration properties can be set in the `tuono.config.ts` file under the `vite` property.
 
-Useful for configuring custom source alias paths during imports, similar to `Next.js`. [ 👉 Read more here](https://vite.dev/config/shared-options)
+### vite.alias
 
-### Vite.optimizeDeps
+Useful for configuring custom source alias paths during imports. [ 👉 Read more here](https://vite.dev/config/shared-options)
+
+> 💡 You can find a working example in the `tuono-tutorial` template or in the documentation itself!
+
+### vite.optimizeDeps
 
 Vite's dependency optimizer used only during dev. [ 👉 Read more here](https://vite.dev/config/dep-optimization-options)
 
-### Vite.plugins
+### vite.plugins
 
 Useful for extending vite's functionality. [ 👉 Read more here](https://vite.dev/guide/using-plugins)
-
-
-## Using Vite alias for Path configuration
-
-With aliases, you can call in your imports very similar to `Next.js` framework:
-
-```typescript
-// Instead of
-import MyComponent from '../../../components/MyComponent'; // relative to src folder
-
-// You can use
-import MyComponent from '@/components/MyComponent'; // considers 'src' as baseFolder
-```
-
-To achieve this, you need to add the following configuration to your `tuono.config.ts`
-
-```typescript
-// ->> tuono.config.ts
-import type { TuonoConfig } from "tuono/config";
-import path, { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-
-function getDirname(importMetaUrl: string): string {
-  return dirname(fileURLToPath(importMetaUrl));
-}
-
-const __dirname = getDirname(import.meta.url);
-
-const config: TuonoConfig = {
-  vite: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-    
-  },
-};
-
-export default config;
-```
-
-As Tuono uses Typescript, you should also update `compilerOptions` under `tsconfig.json` file to include these aliases for proper type checking
-
-> *NOTE: please add the following code-snippet under `compilerOptions` and not replace `tsconfig.json`*
-
-```json
-/* ->> tsconfig.json*/
-{
-  "compilerOptions": {
-    ...
-    /* src alias "@" configuration */
-    "baseUrl": ".",
-    "paths": {
-      "@/*": [
-        "src/*"
-      ]
-    },
-    ...
-  }
-}
-```
-
-One last thing is to add `@types/node` to your project, so Typescript stops complaining during file inputs.
-
-```bash
-# add @types/node to your project
-npm i -D @types/node
-```
-
-
-With these you're good to go! ✨
-
----

--- a/apps/documentation/src/routes/documentation/configuration.mdx
+++ b/apps/documentation/src/routes/documentation/configuration.mdx
@@ -12,33 +12,37 @@ import Breadcrumbs, { Element } from '@/components/breadcrumbs'
 # Configuration
 
 `tuono.config.ts` is a configuration file used in Tuono framework to customize aspects of the 
-build process and development environment. Tuono leverages `Vite` - which is a modern, 
-fast build tool and development server for web applications.
+build process and development environment. The config file is written in typescript, so you can rely on type-check and autosuggestion provided by the `TuonoConfig` type,
+which is exported by `tuono/config`.
 
-The `TuonoConfig` interface serves as a wrapper for `vite.config.ts` -
+```ts
+import type { TuonoConfig } from 'tuono/config';
 
-```typescript
-// ->> node_modules/tuono/dist/esm/config/types.d.ts
-export interface TuonoConfig {
-    vite?: {
-        alias?: AliasOptions;
-        optimizeDeps?: DepOptimizationOptions;
-        plugins?: Array<Plugin>;
-    };
-}
+const config: TuonoConfig = { /* typesafe config */ }
+
+export default config
 ```
 
-As of the current version, it supports the following properties 
+## Vite
 
-- `alias`: Useful for configuring custom source alias paths during imports, similar to `Next.js`. [ 👉 Read more here](https://vite.dev/config/shared-options)
-- `optimizeDeps`: Vite's dependency optimizer used only during dev. [ 👉 Read more here](https://vite.dev/config/dep-optimization-options)
-- `plugins`:  Useful for extending vite's functionality. [ 👉 Read more here](https://vite.dev/guide/using-plugins)
+Tuono leverages `Vite` - which is a modern, fast build tool and development server for web applications. The config file `tuono.config.ts` supports the following properties of vite -
 
-We will cover one of the properties `alias` here in detail
+### Vite.alias
 
-## 1. Configure Path Alias in Tuono
+Useful for configuring custom source alias paths during imports, similar to `Next.js`. [ 👉 Read more here](https://vite.dev/config/shared-options)
 
-After configuring aliases, you can use them in your imports (very similar to `Next.js` framework):
+### Vite.optimizeDeps
+
+Vite's dependency optimizer used only during dev. [ 👉 Read more here](https://vite.dev/config/dep-optimization-options)
+
+### Vite.plugins
+
+Useful for extending vite's functionality. [ 👉 Read more here](https://vite.dev/guide/using-plugins)
+
+
+## Using Vite alias for Path configuration
+
+With aliases, you can call in your imports very similar to `Next.js` framework:
 
 ```typescript
 // Instead of
@@ -105,48 +109,4 @@ npm i -D @types/node
 
 With these you're good to go! ✨
 
-## Practical Usecases
-
-### 01. Design libraries - ShadCN
-
-You can use libraries like `ShadCN` along with Tuono with this feature. Just follow their instruction on `Vite` site  upto `Step 03`. [👉 Link provided here](https://ui.shadcn.com/docs/installation/vite)
-
-### 02. More Path Aliases
-
-You can even keep extending aliases to `@components` or `@services` by just adding them to `tuono.config.ts` like so -
-
-```typescript
-// ->> tuono.config.ts
-// NOTE: 💡 THIS IS COMPLETELY OPTIONAL
-import type { TuonoConfig } from "tuono/config";
-import path, { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-
-function getDirname(importMetaUrl: string): string {
-  return dirname(fileURLToPath(importMetaUrl));
-}
-
-const __dirname = getDirname(import.meta.url);
-
-const config: TuonoConfig = {
-  vite: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      // NOTE: 💡 only works if you have a 'components' & 'services' folder under 'src'
-      // NOTE: 💡 similarly, you need to also configure tsconfig.json
-      '@components': path.resolve(__dirname, './src/components'), // ..optional
-      '@services': path.resolve(__dirname, './src/services'), // ..optional
-    },
-    
-  },
-};
-
-export default config;
-
-
-```
-
 ---
-
-
-

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -74,10 +74,11 @@ cargo build
 #### Introduction
 
 Docker takes care of configuring the development environment, so you don’t need to worry about installing specific versions of packages like Node.js or pnpm. The Docker image handles this for you!
-Using Docker, **the only operations you’ll need to manage on your host machine are related to git**. (don't use phpnm, cargo, ... from your host machine)
+Using Docker, **the only operations you’ll need to manage on your host machine are related to git**. (don't use pnpm, cargo, ... from your host machine)
 Some IDEs (such as vscode with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)) allow you to connect directly to the Docker container.
 
-**Before proceeding with this guide, make sure that the `node_modules` and `target` directories are either absent or empty in the subprojects of Tuono from your host machine where you want to contribute.** This ensures a clean and consistent environment when using Docker.
+**Before proceeding with this guide, make sure that the `node_modules` and `target` directories are either absent or empty in the subprojects of Tuono from your host machine where you want to contribute.**
+This ensures a clean and consistent environment when using Docker.
 
 #### Build the Tuono's Docker Container
 


### PR DESCRIPTION
## Context & Description

Close #303

Fill [tuono.config.ts](https://tuono.dev/documentation/configuration) with `vite`  references.


