### PR TITLE
docs: Add useRouter Documentation

### DIFF
--- a/apps/documentation/src/routes/documentation/hooks/use-router.mdx
+++ b/apps/documentation/src/routes/documentation/hooks/use-router.mdx
@@ -11,7 +11,7 @@ import Breadcrumbs, { Element } from '@/components/breadcrumbs'
 
 # useRouter
 
-The useRouter hook provides access to various data about the current route. It returns a `UseRouterResult` interface, which can be used to access route data, and to navigate between pages, as seen in the below example:
+The useRouter hook provides access to various data about the current route. It returns an object of interface `UseRouterResult`, which can be used to access route data, and to navigate between pages, as seen in the below example:
 
 ```
 import { useRouter } from 'tuono'
@@ -25,9 +25,12 @@ export default function IndexPage() {
   }
 
   return (
-    <a href={"/foo"} onClick={handleClick}>
-      My link
-    </a>
+    <>
+      <p>pathname: {router.pathname}</p>
+      <a href={"/foo"} onClick={handleClick}>
+        My link
+      </a>
+    </>
   )
 }
 ```

--- a/apps/documentation/src/routes/documentation/hooks/use-router.mdx
+++ b/apps/documentation/src/routes/documentation/hooks/use-router.mdx
@@ -11,4 +11,23 @@ import Breadcrumbs, { Element } from '@/components/breadcrumbs'
 
 # useRouter
 
-TODO
+The useRouter hook provides access to various data about the current route. It returns a `UseRouterResult` interface, which can be used to access route data, and to navigate between pages, as seen in the below example:
+
+```
+import { useRouter } from 'tuono'
+
+export default function IndexPage() {
+  const router = useRouter()
+
+  const handleClick = (e) => {
+    e.preventDefault()
+    router.push("/foo")
+  }
+
+  return (
+    <a href={"/foo"} onClick={handleClick}>
+      My link
+    </a>
+  )
+}
+```

--- a/apps/documentation/src/routes/documentation/hooks/use-router.mdx
+++ b/apps/documentation/src/routes/documentation/hooks/use-router.mdx
@@ -36,12 +36,14 @@ export default function IndexPage() {
 ```
 
 ## `router` object
+
 - `pathname`: `string` - Returns the current path name
 - `query`: `Record<string, unknown>` - This object contains all the query params of the current route
 
 The following methods are included inside `router`:
 
 ### router.push
+
 Handles client side page navigation quickly. Useful for internal links, or for when you need to change url in some JS.
 
 ```

--- a/apps/documentation/src/routes/documentation/hooks/use-router.mdx
+++ b/apps/documentation/src/routes/documentation/hooks/use-router.mdx
@@ -11,25 +11,20 @@ import Breadcrumbs, { Element } from '@/components/breadcrumbs'
 
 # useRouter
 
-The useRouter hook provides access to various data about the current route. It returns an object of interface `UseRouterResult`, which can be used to access route data, and to navigate between pages, as seen in the below example:
+The `useRouter` hook provides access to various data about the current route, as well as methods to navigate between pages, as seen in the below example:
 
-```
+```typescript jsx
 import { useRouter } from 'tuono'
 
 export default function IndexPage() {
   const router = useRouter()
 
-  const handleClick = (e) => {
-    e.preventDefault()
-    router.push("/foo")
-  }
-
   return (
     <>
       <p>pathname: {router.pathname}</p>
-      <a href={"/foo"} onClick={handleClick}>
+      <button onClick={() => router.push("/foo")}>
         My link
-      </a>
+      </button>
     </>
   )
 }
@@ -42,11 +37,11 @@ export default function IndexPage() {
 
 The following methods are included inside `router`:
 
-### router.push
+### `router.push`
 
 Handles client side page navigation quickly. Useful for internal links, or for when you need to change url in some JS.
 
-```
+```ts
 router.push(path, options)
 ```
 

--- a/apps/documentation/src/routes/documentation/hooks/use-router.mdx
+++ b/apps/documentation/src/routes/documentation/hooks/use-router.mdx
@@ -31,3 +31,20 @@ export default function IndexPage() {
   )
 }
 ```
+
+## `router` object
+- `pathname`: `string` - Returns the current path name
+- `query`: `Record<string, unknown>` - This object contains all the query params of the current route
+
+The following methods are included inside `router`:
+
+### router.push
+Handles client side page navigation quickly. Useful for internal links, or for when you need to change url in some JS.
+
+```
+router.push(path, options)
+```
+
+- `path`: `string` - The path of the page you want to navigate to
+- `options`: `PushOptions` - Optional config object for additional control
+  - `scroll`: `boolean` - If `false` the scroll offset will be kept across page navigation. Default `true`


### PR DESCRIPTION
## Context & Description

See [this discord thread](https://discordapp.com/channels/1307411506735874208/1328297481343336469). This PR adds documentation for the `useRouter` hook, including an example, documentation for the returned router object, and all methods returned (so far only router.push).

I like to rebase and squash PRs into one commit because I think it keeps history cleaner, so it might be a bit messy until I do that :)