### PR TITLE
chore: remove `RouterProvider` from `tuono` exports

### DIFF
--- a/packages/tuono/src/index.ts
+++ b/packages/tuono/src/index.ts
@@ -3,7 +3,6 @@ export {
   createRootRoute,
   createRouter,
   Link,
-  RouterProvider,
   dynamic,
   useRouter,
   __tuono__internal__lazyLoadComponent,


### PR DESCRIPTION
## Context & Description

Fixes #252 