### PR TITLE
chore(renovate): change `prConcurrentLimit` to 5 (default 10) and schedule once per week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["every 2 weeks on monday"],
+  "schedule": ["every Monday"],
   "prConcurrentLimit": 5,
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["every 2 weeks on monday"],
+  "prConcurrentLimit": 5,
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
## Context & Description

Reduce `prConcurrentLimit` to 5 to avoid cluttering pull requests list with many automated PRs.

https://docs.renovatebot.com/configuration-options/#prconcurrentlimit

> This setting - if enabled - limits Renovate to a maximum of x concurrent PRs open at any time.
> This limit is enforced on a per-repository basis.


