### PR TITLE
docs(configuration): add types and reformat `vite` properties

### DIFF
--- a/apps/documentation/src/routes/documentation/configuration.mdx
+++ b/apps/documentation/src/routes/documentation/configuration.mdx
@@ -36,14 +36,24 @@ As a result, **some** Vite configuration properties can be set in the `tuono.con
 
 ### vite.alias
 
-Useful for configuring custom source alias paths during imports. [ 👉 Read more here](https://vite.dev/config/shared-options)
+Useful for configuring custom source alias paths during imports
+
+- Type:
+  - `Record<string, string>`
+  - `Array<{ find: string | RegExp, replacement: string, customResolver?: ResolverFunction | ResolverObject }>`
+- [Vite documentation: resolve.alias](https://vite.dev/config/shared-options#resolve-alias)
 
 > 💡 You can find a working example in the `tuono-tutorial` template or in the documentation itself!
 
 ### vite.optimizeDeps
 
-Vite's dependency optimizer used only during dev. [ 👉 Read more here](https://vite.dev/config/dep-optimization-options)
+Vite's dependency optimizer used only during dev
+
+- [Vite documentation: Dep Optimization Options](https://vite.dev/config/dep-optimization-options)
 
 ### vite.plugins
 
-Useful for extending vite's functionality. [ 👉 Read more here](https://vite.dev/guide/using-plugins)
+Useful for extending vite's functionality
+
+- Type: `Array<Plugin | Array<Plugin> | Promise<Plugin | Array<Plugin>>`
+- [Vite documentation: plugins](https://vite.dev/guide/using-plugins)


### PR DESCRIPTION
## Context & Description

Added types and vite documentation for each vite option.

> [!NOTE]
> `vite.optimizeDeps` doesn't have a type because it's very complex.
> Note that this option has a standalone page inside vite documentation. 

<details><summary>Page preview</summary>
<p>

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/d99c1566-121f-4b06-8f5b-5b803774ad3c" />


</p>
</details> 

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

Bug fixes and new features should include tests.

PR guide: https://tuono.dev/documentation/contributing/pull-requests
-->
