### PR TITLE
fix(deps): update dependency vite to v5.4.12 [security]

### DIFF
--- a/packages/tuono-fs-router-vite-plugin/package.json
+++ b/packages/tuono-fs-router-vite-plugin/package.json
@@ -47,7 +47,7 @@
     "@babel/core": "^7.24.4",
     "@babel/types": "^7.24.0",
     "prettier": "^3.2.4",
-    "vite": "^5.2.11"
+    "vite": "^5.2.12"
   },
   "devDependencies": {
     "@tanstack/config": "0.7.13",

--- a/packages/tuono-router/package.json
+++ b/packages/tuono-router/package.json
@@ -57,7 +57,7 @@
     "@vitejs/plugin-react-swc": "3.7.2",
     "jsdom": "25.0.1",
     "react": "19.0.0",
-    "vite": "5.4.11",
+    "vite": "5.4.12",
     "vitest": "2.1.8"
   }
 }

--- a/packages/tuono/package.json
+++ b/packages/tuono/package.json
@@ -100,7 +100,7 @@
     "fast-text-encoding": "^1.0.6",
     "tuono-fs-router-vite-plugin": "workspace:*",
     "tuono-router": "workspace:*",
-    "vite": "^5.2.11",
+    "vite": "^5.2.12",
     "web-streams-polyfill": "^4.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,11 +73,11 @@ importers:
         version: 4.0.0
       tuono:
         specifier: npm:tuono@0.17.3
-        version: 0.17.3(@types/node@22.10.7)(lightningcss@1.29.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.25.0)(sugarss@4.0.1(postcss@8.5.1))
+        version: 0.17.3(@types/node@22.10.7)(lightningcss@1.29.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.31.0)(sugarss@4.0.1(postcss@8.5.1))
     devDependencies:
       '@mdx-js/rollup':
         specifier: 3.1.0
-        version: 3.1.0(acorn@8.14.0)(rollup@4.25.0)
+        version: 3.1.0(acorn@8.14.0)(rollup@4.31.0)
       '@types/react':
         specifier: 19.0.7
         version: 19.0.7
@@ -155,7 +155,7 @@ importers:
     devDependencies:
       '@mdx-js/rollup':
         specifier: 3.1.0
-        version: 3.1.0(acorn@8.14.0)(rollup@4.25.0)
+        version: 3.1.0(acorn@8.14.0)(rollup@4.31.0)
       '@types/react':
         specifier: ^19.0.2
         version: 19.0.7
@@ -170,7 +170,7 @@ importers:
     dependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0-beta.9
-        version: 4.0.0-beta.9(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+        version: 4.0.0-beta.9(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -207,10 +207,10 @@ importers:
         version: 7.25.9(@babel/core@7.26.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.25.0)
+        version: 5.0.5(rollup@4.31.0)
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.0
-        version: 3.7.2(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+        version: 3.7.2(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
       fast-text-encoding:
         specifier: ^1.0.6
         version: 1.0.6
@@ -221,15 +221,15 @@ importers:
         specifier: workspace:*
         version: link:../tuono-router
       vite:
-        specifier: ^5.2.11
-        version: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+        specifier: ^5.2.12
+        version: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
       web-streams-polyfill:
         specifier: ^4.0.0
         version: 4.0.0
     devDependencies:
       '@tanstack/config':
         specifier: 0.7.13
-        version: 0.7.13(@types/node@22.10.7)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+        version: 0.7.13(@types/node@22.10.7)(esbuild@0.21.5)(rollup@4.31.0)(typescript@5.7.3)(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
       '@types/babel__core':
         specifier: 7.20.5
         version: 7.20.5
@@ -267,12 +267,12 @@ importers:
         specifier: ^3.2.4
         version: 3.4.2
       vite:
-        specifier: ^5.2.11
-        version: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+        specifier: ^5.2.12
+        version: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
     devDependencies:
       '@tanstack/config':
         specifier: 0.7.13
-        version: 0.7.13(@types/node@22.10.7)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+        version: 0.7.13(@types/node@22.10.7)(esbuild@0.21.5)(rollup@4.31.0)(typescript@5.7.3)(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -288,7 +288,7 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: 0.7.13
-        version: 0.7.13(@types/node@22.10.7)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+        version: 0.7.13(@types/node@22.10.7)(esbuild@0.21.5)(rollup@4.31.0)(typescript@5.7.3)(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
       '@testing-library/jest-dom':
         specifier: 6.6.3
         version: 6.6.3
@@ -300,7 +300,7 @@ importers:
         version: 19.0.7
       '@vitejs/plugin-react-swc':
         specifier: 3.7.2
-        version: 3.7.2(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+        version: 3.7.2(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
       jsdom:
         specifier: 25.0.1
         version: 25.0.1
@@ -308,8 +308,8 @@ importers:
         specifier: 19.0.0
         version: 19.0.0
       vite:
-        specifier: 5.4.11
-        version: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+        specifier: 5.4.12
+        version: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
       vitest:
         specifier: 2.1.8
         version: 2.1.8(@types/node@22.10.7)(jsdom@25.0.1)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
@@ -732,93 +732,98 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.25.0':
-    resolution: {integrity: sha512-CC/ZqFZwlAIbU1wUPisHyV/XRc5RydFrNLtgl3dGYskdwPZdt4HERtKm50a/+DtTlKeCq9IXFEWR+P6blwjqBA==}
+  '@rollup/rollup-android-arm-eabi@4.31.0':
+    resolution: {integrity: sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.25.0':
-    resolution: {integrity: sha512-/Y76tmLGUJqVBXXCfVS8Q8FJqYGhgH4wl4qTA24E9v/IJM0XvJCGQVSW1QZ4J+VURO9h8YCa28sTFacZXwK7Rg==}
+  '@rollup/rollup-android-arm64@4.31.0':
+    resolution: {integrity: sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.25.0':
-    resolution: {integrity: sha512-YVT6L3UrKTlC0FpCZd0MGA7NVdp7YNaEqkENbWQ7AOVOqd/7VzyHpgIpc1mIaxRAo1ZsJRH45fq8j4N63I/vvg==}
+  '@rollup/rollup-darwin-arm64@4.31.0':
+    resolution: {integrity: sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.25.0':
-    resolution: {integrity: sha512-ZRL+gexs3+ZmmWmGKEU43Bdn67kWnMeWXLFhcVv5Un8FQcx38yulHBA7XR2+KQdYIOtD0yZDWBCudmfj6lQJoA==}
+  '@rollup/rollup-darwin-x64@4.31.0':
+    resolution: {integrity: sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.25.0':
-    resolution: {integrity: sha512-xpEIXhiP27EAylEpreCozozsxWQ2TJbOLSivGfXhU4G1TBVEYtUPi2pOZBnvGXHyOdLAUUhPnJzH3ah5cqF01g==}
+  '@rollup/rollup-freebsd-arm64@4.31.0':
+    resolution: {integrity: sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.25.0':
-    resolution: {integrity: sha512-sC5FsmZGlJv5dOcURrsnIK7ngc3Kirnx3as2XU9uER+zjfyqIjdcMVgzy4cOawhsssqzoAX19qmxgJ8a14Qrqw==}
+  '@rollup/rollup-freebsd-x64@4.31.0':
+    resolution: {integrity: sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.25.0':
-    resolution: {integrity: sha512-uD/dbLSs1BEPzg564TpRAQ/YvTnCds2XxyOndAO8nJhaQcqQGFgv/DAVko/ZHap3boCvxnzYMa3mTkV/B/3SWA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.31.0':
+    resolution: {integrity: sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.25.0':
-    resolution: {integrity: sha512-ZVt/XkrDlQWegDWrwyC3l0OfAF7yeJUF4fq5RMS07YM72BlSfn2fQQ6lPyBNjt+YbczMguPiJoCfaQC2dnflpQ==}
+  '@rollup/rollup-linux-arm-musleabihf@4.31.0':
+    resolution: {integrity: sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.25.0':
-    resolution: {integrity: sha512-qboZ+T0gHAW2kkSDPHxu7quaFaaBlynODXpBVnPxUgvWYaE84xgCKAPEYE+fSMd3Zv5PyFZR+L0tCdYCMAtG0A==}
+  '@rollup/rollup-linux-arm64-gnu@4.31.0':
+    resolution: {integrity: sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.25.0':
-    resolution: {integrity: sha512-ndWTSEmAaKr88dBuogGH2NZaxe7u2rDoArsejNslugHZ+r44NfWiwjzizVS1nUOHo+n1Z6qV3X60rqE/HlISgw==}
+  '@rollup/rollup-linux-arm64-musl@4.31.0':
+    resolution: {integrity: sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.25.0':
-    resolution: {integrity: sha512-BVSQvVa2v5hKwJSy6X7W1fjDex6yZnNKy3Kx1JGimccHft6HV0THTwNtC2zawtNXKUu+S5CjXslilYdKBAadzA==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.31.0':
+    resolution: {integrity: sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.31.0':
+    resolution: {integrity: sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.25.0':
-    resolution: {integrity: sha512-G4hTREQrIdeV0PE2JruzI+vXdRnaK1pg64hemHq2v5fhv8C7WjVaeXc9P5i4Q5UC06d/L+zA0mszYIKl+wY8oA==}
+  '@rollup/rollup-linux-riscv64-gnu@4.31.0':
+    resolution: {integrity: sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.25.0':
-    resolution: {integrity: sha512-9T/w0kQ+upxdkFL9zPVB6zy9vWW1deA3g8IauJxojN4bnz5FwSsUAD034KpXIVX5j5p/rn6XqumBMxfRkcHapQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.31.0':
+    resolution: {integrity: sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.25.0':
-    resolution: {integrity: sha512-ThcnU0EcMDn+J4B9LD++OgBYxZusuA7iemIIiz5yzEcFg04VZFzdFjuwPdlURmYPZw+fgVrFzj4CA64jSTG4Ig==}
+  '@rollup/rollup-linux-x64-gnu@4.31.0':
+    resolution: {integrity: sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.25.0':
-    resolution: {integrity: sha512-zx71aY2oQxGxAT1JShfhNG79PnjYhMC6voAjzpu/xmMjDnKNf6Nl/xv7YaB/9SIa9jDYf8RBPWEnjcdlhlv1rQ==}
+  '@rollup/rollup-linux-x64-musl@4.31.0':
+    resolution: {integrity: sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.25.0':
-    resolution: {integrity: sha512-JT8tcjNocMs4CylWY/CxVLnv8e1lE7ff1fi6kbGocWwxDq9pj30IJ28Peb+Y8yiPNSF28oad42ApJB8oUkwGww==}
+  '@rollup/rollup-win32-arm64-msvc@4.31.0':
+    resolution: {integrity: sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.25.0':
-    resolution: {integrity: sha512-dRLjLsO3dNOfSN6tjyVlG+Msm4IiZnGkuZ7G5NmpzwF9oOc582FZG05+UdfTbz5Jd4buK/wMb6UeHFhG18+OEg==}
+  '@rollup/rollup-win32-ia32-msvc@4.31.0':
+    resolution: {integrity: sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.25.0':
-    resolution: {integrity: sha512-/RqrIFtLB926frMhZD0a5oDa4eFIbyNEwLLloMTEjmqfwZWXywwVVOVmwTsuyhC9HKkVEZcOOi+KV4U9wmOdlg==}
+  '@rollup/rollup-win32-x64-msvc@4.31.0':
+    resolution: {integrity: sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==}
     cpu: [x64]
     os: [win32]
 
@@ -2961,8 +2966,8 @@ packages:
     peerDependencies:
       rollup: 2.x || 3.x || 4.x
 
-  rollup@4.25.0:
-    resolution: {integrity: sha512-uVbClXmR6wvx5R1M3Od4utyLUxrmOcEm3pAtMphn73Apq19PDtHpgZoEvqH2YnnaNUuvKmg2DgRd2Sqv+odyqg==}
+  rollup@4.31.0:
+    resolution: {integrity: sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3467,8 +3472,8 @@ packages:
       vite:
         optional: true
 
-  vite@5.4.11:
-    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
+  vite@5.4.12:
+    resolution: {integrity: sha512-KwUaKB27TvWwDJr1GjjWthLMATbGEbeWYZIbGZ5qFIsgPP3vWzLu4cVooqhm5/Z2SPDUMjyPVjTztm5tYKwQxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -4001,11 +4006,11 @@ snapshots:
       '@types/react': 19.0.7
       react: 19.0.0
 
-  '@mdx-js/rollup@3.1.0(acorn@8.14.0)(rollup@4.25.0)':
+  '@mdx-js/rollup@3.1.0(acorn@8.14.0)(rollup@4.31.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
-      '@rollup/pluginutils': 5.1.3(rollup@4.25.0)
-      rollup: 4.25.0
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
+      rollup: 4.31.0
       source-map: 0.7.4
       vfile: 6.0.3
     transitivePeerDependencies:
@@ -4061,74 +4066,77 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@rollup/plugin-inject@5.0.5(rollup@4.25.0)':
+  '@rollup/plugin-inject@5.0.5(rollup@4.31.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.25.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       estree-walker: 2.0.2
       magic-string: 0.30.17
     optionalDependencies:
-      rollup: 4.25.0
+      rollup: 4.31.0
 
-  '@rollup/pluginutils@5.1.3(rollup@4.25.0)':
+  '@rollup/pluginutils@5.1.3(rollup@4.31.0)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.25.0
+      rollup: 4.31.0
 
-  '@rollup/rollup-android-arm-eabi@4.25.0':
+  '@rollup/rollup-android-arm-eabi@4.31.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.25.0':
+  '@rollup/rollup-android-arm64@4.31.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.25.0':
+  '@rollup/rollup-darwin-arm64@4.31.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.25.0':
+  '@rollup/rollup-darwin-x64@4.31.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.25.0':
+  '@rollup/rollup-freebsd-arm64@4.31.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.25.0':
+  '@rollup/rollup-freebsd-x64@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.25.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.25.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.25.0':
+  '@rollup/rollup-linux-arm64-gnu@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.25.0':
+  '@rollup/rollup-linux-arm64-musl@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.25.0':
+  '@rollup/rollup-linux-loongarch64-gnu@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.25.0':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.25.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.25.0':
+  '@rollup/rollup-linux-s390x-gnu@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.25.0':
+  '@rollup/rollup-linux-x64-gnu@4.31.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.25.0':
+  '@rollup/rollup-linux-x64-musl@4.31.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.25.0':
+  '@rollup/rollup-win32-arm64-msvc@4.31.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.25.0':
+  '@rollup/rollup-win32-ia32-msvc@4.31.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.31.0':
     optional: true
 
   '@rtsao/scc@1.1.0': {}
@@ -4277,15 +4285,15 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.0.0-beta.9
       '@tailwindcss/oxide-win32-x64-msvc': 4.0.0-beta.9
 
-  '@tailwindcss/vite@4.0.0-beta.9(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))':
+  '@tailwindcss/vite@4.0.0-beta.9(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))':
     dependencies:
       '@tailwindcss/node': 4.0.0-beta.9
       '@tailwindcss/oxide': 4.0.0-beta.9
       lightningcss: 1.29.1
       tailwindcss: 4.0.0-beta.9
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
 
-  '@tanstack/config@0.7.13(@types/node@22.10.7)(esbuild@0.21.5)(rollup@4.25.0)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))':
+  '@tanstack/config@0.7.13(@types/node@22.10.7)(esbuild@0.21.5)(rollup@4.31.0)(typescript@5.7.3)(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))':
     dependencies:
       '@commitlint/parse': 19.5.0
       commander: 12.1.0
@@ -4295,13 +4303,13 @@ snapshots:
       jsonfile: 6.1.0
       liftoff: 5.0.0
       minimist: 1.2.8
-      rollup-plugin-preserve-directives: 0.4.0(rollup@4.25.0)
+      rollup-plugin-preserve-directives: 0.4.0(rollup@4.31.0)
       semver: 7.6.3
       simple-git: 3.27.0
       v8flags: 4.0.1
-      vite-plugin-dts: 3.9.1(@types/node@22.10.7)(rollup@4.25.0)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
-      vite-plugin-externalize-deps: 0.8.0(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
-      vite-tsconfig-paths: 4.3.2(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+      vite-plugin-dts: 3.9.1(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+      vite-plugin-externalize-deps: 0.8.0(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+      vite-tsconfig-paths: 4.3.2(typescript@5.7.3)(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
     transitivePeerDependencies:
       - '@types/node'
       - esbuild
@@ -4503,10 +4511,10 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-react-swc@3.7.2(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))':
+  '@vitejs/plugin-react-swc@3.7.2(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))':
     dependencies:
       '@swc/core': 1.9.3
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -4517,13 +4525,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))':
+  '@vitest/mocker@2.1.8(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -6819,34 +6827,35 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rollup-plugin-preserve-directives@0.4.0(rollup@4.25.0):
+  rollup-plugin-preserve-directives@0.4.0(rollup@4.31.0):
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.25.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       magic-string: 0.30.17
-      rollup: 4.25.0
+      rollup: 4.31.0
 
-  rollup@4.25.0:
+  rollup@4.31.0:
     dependencies:
       '@types/estree': 1.0.6
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.25.0
-      '@rollup/rollup-android-arm64': 4.25.0
-      '@rollup/rollup-darwin-arm64': 4.25.0
-      '@rollup/rollup-darwin-x64': 4.25.0
-      '@rollup/rollup-freebsd-arm64': 4.25.0
-      '@rollup/rollup-freebsd-x64': 4.25.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.25.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.25.0
-      '@rollup/rollup-linux-arm64-gnu': 4.25.0
-      '@rollup/rollup-linux-arm64-musl': 4.25.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.25.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.25.0
-      '@rollup/rollup-linux-s390x-gnu': 4.25.0
-      '@rollup/rollup-linux-x64-gnu': 4.25.0
-      '@rollup/rollup-linux-x64-musl': 4.25.0
-      '@rollup/rollup-win32-arm64-msvc': 4.25.0
-      '@rollup/rollup-win32-ia32-msvc': 4.25.0
-      '@rollup/rollup-win32-x64-msvc': 4.25.0
+      '@rollup/rollup-android-arm-eabi': 4.31.0
+      '@rollup/rollup-android-arm64': 4.31.0
+      '@rollup/rollup-darwin-arm64': 4.31.0
+      '@rollup/rollup-darwin-x64': 4.31.0
+      '@rollup/rollup-freebsd-arm64': 4.31.0
+      '@rollup/rollup-freebsd-x64': 4.31.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.31.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.31.0
+      '@rollup/rollup-linux-arm64-gnu': 4.31.0
+      '@rollup/rollup-linux-arm64-musl': 4.31.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.31.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.31.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.31.0
+      '@rollup/rollup-linux-s390x-gnu': 4.31.0
+      '@rollup/rollup-linux-x64-gnu': 4.31.0
+      '@rollup/rollup-linux-x64-musl': 4.31.0
+      '@rollup/rollup-win32-arm64-msvc': 4.31.0
+      '@rollup/rollup-win32-ia32-msvc': 4.31.0
+      '@rollup/rollup-win32-x64-msvc': 4.31.0
       fsevents: 2.3.3
 
   rrweb-cssom@0.7.1: {}
@@ -7120,7 +7129,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/types': 7.26.3
       prettier: 3.4.2
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7139,19 +7148,19 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  tuono@0.17.3(@types/node@22.10.7)(lightningcss@1.29.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.25.0)(sugarss@4.0.1(postcss@8.5.1)):
+  tuono@0.17.3(@types/node@22.10.7)(lightningcss@1.29.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.31.0)(sugarss@4.0.1(postcss@8.5.1)):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.25.0)
-      '@vitejs/plugin-react-swc': 3.7.2(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+      '@rollup/plugin-inject': 5.0.5(rollup@4.31.0)
+      '@vitejs/plugin-react-swc': 3.7.2(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
       fast-text-encoding: 1.0.6
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tuono-fs-router-vite-plugin: 0.17.3(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
       tuono-router: 0.17.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
       web-streams-polyfill: 4.0.0
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -7364,7 +7373,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7376,10 +7385,10 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@3.9.1(@types/node@22.10.7)(rollup@4.25.0)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))):
+  vite-plugin-dts@3.9.1(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@22.10.7)
-      '@rollup/pluginutils': 5.1.3(rollup@4.25.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.31.0)
       '@vue/language-core': 1.8.27(typescript@5.7.3)
       debug: 4.4.0
       kolorist: 1.8.0
@@ -7387,32 +7396,32 @@ snapshots:
       typescript: 5.7.3
       vue-tsc: 1.8.27(typescript@5.7.3)
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-externalize-deps@0.8.0(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))):
+  vite-plugin-externalize-deps@0.8.0(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))):
     dependencies:
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
 
-  vite-tsconfig-paths@4.3.2(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))):
+  vite-tsconfig-paths@4.3.2(typescript@5.7.3)(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.7.3)
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)):
+  vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
-      rollup: 4.25.0
+      rollup: 4.31.0
     optionalDependencies:
       '@types/node': 22.10.7
       fsevents: 2.3.3
@@ -7422,7 +7431,7 @@ snapshots:
   vitest@2.1.8(@types/node@22.10.7)(jsdom@25.0.1)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
+      '@vitest/mocker': 2.1.8(vite@5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1)))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -7438,7 +7447,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
+      vite: 5.4.12(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
       vite-node: 2.1.8(@types/node@22.10.7)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Context & Description

Superseds #400 

- adds `pnpm dedupe`
- update version range for `tuono` and `tuono-router` packages

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

Bug fixes and new features should include tests.

PR guide: https://tuono.dev/documentation/contributing/pull-requests
-->
