### PR TITLE
ci(docs): use tuono 0.17.3 in docs workflows

### DIFF
--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install tuono
-        run: cargo install tuono@0.16.9
+        run: cargo install tuono@0.17.3
 
       - name: Build project
         working-directory: ./apps/documentation

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install tuono
-        run: cargo install tuono@0.16.9
+        run: cargo install tuono@0.17.3
 
       - name: Build project
         working-directory: ./apps/documentation


### PR DESCRIPTION
## Context & Description

docs related workflows were still using `tuono@0.16.9` rust version.

## Considerations

1. How about adding a section inside contributing about docs maintenance?
2. We could throw an error if the js version is not aligned with the rust binary version when running `dev` and `build` commands. 
   [There is already a task on the v1 project ](https://github.com/orgs/tuono-labs/projects/2/views/1?pane=issue&itemId=89204577).
   Maybe we could convert the project item into an issue so is more visible and maybe someone who want to tackle with the rust part could take care of it?

WDYT?
