### PR TITLE
fix(packages/tuono): build error when config contains vite plugins

### DIFF
--- a/packages/tuono/src/build/config/create-json-config.spec.ts
+++ b/packages/tuono/src/build/config/create-json-config.spec.ts
@@ -1,0 +1,32 @@
+import fs from 'fs/promises'
+
+import { describe, expect, it, vitest } from 'vitest'
+import react from '@vitejs/plugin-react-swc'
+
+import { createJsonConfig } from './create-json-config'
+
+const writeFileSpy = vitest.spyOn(fs, 'writeFile').mockResolvedValue(void 0)
+
+describe('createJsonConfig', () => {
+  const sampleConfig = { server: { host: 'h', port: 1 } }
+
+  it('should process config with only server property', async () => {
+    await createJsonConfig(sampleConfig)
+
+    expect(writeFileSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining(JSON.stringify(sampleConfig)),
+      expect.any(String),
+    )
+  })
+
+  it('should process config with plugins', async () => {
+    await createJsonConfig({ ...sampleConfig, vite: { plugins: [react()] } })
+
+    expect(writeFileSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining(JSON.stringify(sampleConfig)),
+      expect.any(String),
+    )
+  })
+})

--- a/packages/tuono/src/build/config/create-json-config.ts
+++ b/packages/tuono/src/build/config/create-json-config.ts
@@ -21,9 +21,25 @@ const CONFIG_PATH = path.join(
 function removeViteProperties(
   config: InternalTuonoConfig,
 ): Omit<InternalTuonoConfig, 'vite'> {
-  const newConfig = structuredClone(config)
-  delete newConfig['vite']
-  return newConfig
+  /**
+   * Using {@link structuredClone} cause the following errors based on runtime env:
+   * ```text
+   * node
+   * DOMException [DataCloneError]: configureServer(s){a.push(s)} could not be cloned.
+   *
+   * vitest
+   * DataCloneError: (id) => id === runtimePublicPath ? id : void 0 could not be cloned.
+   * ```
+   * when vite plugins are passed inside to the config.
+   *
+   * Since the purpose of this function is to remove the vite object
+   * we are going to use destructing rather than {@link structuredClone} and `delete`
+   *
+   * @see https://github.com/tuono-labs/tuono/issues/414
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { vite, ...configRest } = config
+  return structuredClone(configRest)
 }
 
 /**


### PR DESCRIPTION
## Context & Description

Close #414.

The error was caused by the serialisation via structuredClone of a configuration containing a vite plugin.
More info can be found on `packages/tuono/src/build/config/create-json-config.ts`

Relevant unit tests were added to avoid regression.
