### PR TITLE
docs: remove `$` from command line snippets

### DIFF
--- a/apps/documentation/README.md
+++ b/apps/documentation/README.md
@@ -3,5 +3,5 @@
 This is the starter tuono project. To download it run in your terminal:
 
 ```shell
-$ tuono new [NAME]
+tuono new [NAME]
 ```

--- a/apps/documentation/src/components/Hero/Hero.tsx
+++ b/apps/documentation/src/components/Hero/Hero.tsx
@@ -36,7 +36,7 @@ export default function Hero(): JSX.Element {
                 size="lg"
                 style={{ border: 'solid 1px var(--mantine-color-violet-1)' }}
                 color="gray"
-                leftSection="$ cargo install tuono"
+                leftSection="cargo install tuono"
                 rightSection={
                   copied ? (
                     <IconCheck style={{ width: rem(20) }} />

--- a/apps/documentation/src/routes/documentation/tutorial/api-fetching.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/api-fetching.mdx
@@ -77,7 +77,7 @@ You can load them in the `ApplicationState` of your app inside the `./src/app.rs
 To install it just run in your terminal:
 
 ```bash
-$ cargo add reqwest
+cargo add reqwest
 ```
 
 A new entry has just been added to your `Cargo.toml` file.

--- a/apps/documentation/src/routes/documentation/tutorial/development-setup.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/development-setup.mdx
@@ -22,13 +22,13 @@ import Breadcrumbs from '@/components/Breadcrumbs'
 To set up a new fresh project you just need to run the following command:
 
 ```
-$ tuono new tuono-tutorial
+tuono new tuono-tutorial
 ```
 
 Get into the project folder and install the dependencies with:
 
 ```
-$ npm install
+npm install
 ```
 
 Open it with your favorite code editor.
@@ -59,7 +59,7 @@ CSS modules.
 To start the development environment, you just need to run the following command within the project folder:
 
 ```
-$ tuono dev
+tuono dev
 ```
 
 The first time might take a little bit because it will install all the Rust’s dependencies. All the other execution will be pretty quick!

--- a/apps/documentation/src/routes/documentation/tutorial/index.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/index.mdx
@@ -21,7 +21,7 @@ This tutorial is not meant for people who don't know React - in that case, I sug
 If you prefer to just read the code rather than write you can download the finished tutorial project with:
 
 ```bash
-$ tuono new tutorial --template tuono-tutorial
+tuono new tutorial --template tuono-tutorial
 ```
 
 > I'd love to hear your thoughts about the framework and the tutorial - feel free to reach me at [valerioageno@yahoo.it](mailto:valerioageno@ahoo.it)

--- a/apps/documentation/src/routes/documentation/tutorial/production.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/production.mdx
@@ -21,14 +21,14 @@ The source is now ready to be released. Both server and client have been managed
 to ease the development experience. To build the project to the production state, just run:
 
 ```shell
-$ tuono build
+tuono build
 ```
 
 This command just created the final assets within the `out` directory. To run the production server,
 run:
 
 ```shell
-$ cargo run --release
+cargo run --release
 ```
 
 Check again [`http://localhost:3000/`](http://localhost:3000/) This environment now has all the


### PR DESCRIPTION
docs: Fix command line

## Context & Description

Remove `$ ` prefix .

When I copy code from https://tuono.dev/documentation/tutorial  use copy button, the command with `$ ` need to be removed manually
