### PR TITLE
refactor: move from tuono_lib to tuono

### DIFF
--- a/apps/documentation/Cargo.toml
+++ b/apps/documentation/Cargo.toml
@@ -8,7 +8,7 @@ name = "tuono"
 path = ".tuono/main.rs"
 
 [dependencies]
-tuono_lib = "0.17.5"
+tuono = { package = "tuono_lib", version = "0.17.5" }
 glob = "0.3.1"
 time = { version = "0.3", features = ["macros"] }
 serde = { version = "1.0.202", features = ["derive"] }

--- a/apps/documentation/src/routes/documentation/application-state.mdx
+++ b/apps/documentation/src/routes/documentation/application-state.mdx
@@ -45,7 +45,7 @@ Now the `ApplicationState` is available on all the handlers as following:
 ```rs
 // src/routes/index.rs
 
-#[tuono_lib::handler]
+#[tuono::handler]
 // The first argument always is the Request
 // The ApplicationState arguments are optional. You can use just the ones you need
 // to use in the handler (with no specific order).

--- a/apps/documentation/src/routes/documentation/tutorial/api-fetching.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/api-fetching.mdx
@@ -29,7 +29,7 @@ Clear the `index.rs` file and paste:
 // src/routes/index.rs
 use serde::{Deserialize, Serialize};
 use reqwest::Client;
-use tuono_lib::{Props, Request, Response};
+use tuono::{Props, Request, Response};
 
 const ALL_POKEMON: &str = "https://pokeapi.co/api/v2/pokemon?limit=151";
 
@@ -44,7 +44,7 @@ struct Pokemon {
     url: String,
 }
 
-#[tuono_lib::handler]
+#[tuono::handler]
 async fn get_all_pokemons(_req: Request, fetch: Client) -> Response {
     return match fetch.get(ALL_POKEMON).send().await {
         Ok(res) => {
@@ -93,7 +93,7 @@ name = "tuono"
 path = ".tuono/main.rs"
 
 [dependencies]
-tuono_lib = "0.14.0" # the version might be different
+tuono = { package = "tuono_lib", version = "0.17.5" } # the version might be different
 serde = { version = "1.0.202", features = ["derive"] }
 ++ reqwest = "0.12.9" # the version might be different
 ```

--- a/apps/documentation/src/routes/documentation/tutorial/dynamic-routes.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/dynamic-routes.mdx
@@ -33,7 +33,7 @@ Let’s first work on the server side file. Paste into the new `[pokemon].rs` fi
 // src/routes/pokemons/[pokemon].rs
 use serde::{Deserialize, Serialize};
 use reqwest::Client;
-use tuono_lib::{Props, Request, Response};
+use tuono::{Props, Request, Response};
 
 const POKEMON_API: &str = "https://pokeapi.co/api/v2/pokemon";
 
@@ -45,7 +45,7 @@ struct Pokemon {
     height: u16,
 }
 
-#[tuono_lib::handler]
+#[tuono::handler]
 async fn get_pokemon(req: Request, fetch: Client) -> Response {
     // The param `pokemon` is defined in the route filename [pokemon].rs
     let pokemon = req.params.get("pokemon").unwrap();

--- a/apps/documentation/src/routes/documentation/tutorial/error-handling.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/error-handling.mdx
@@ -29,7 +29,7 @@ Let's see how it works!
 use serde::{Deserialize, Serialize};
 -- use reqwest::Client;
 ++ use reqwest::{Client, StatusCode};
-use tuono_lib::{Props, Request, Response};
+use tuono::{Props, Request, Response};
 
 const POKEMON_API: &str = "https://pokeapi.co/api/v2/pokemon";
 
@@ -41,7 +41,7 @@ struct Pokemon {
     height: u16,
 }
 
-#[tuono_lib::handler]
+#[tuono::handler]
 async fn get_pokemon(req: Request, fetch: Client) -> Response {
     // The param `pokemon` is defined in the route filename [pokemon].rs
     let pokemon = req.params.get("pokemon").unwrap();
@@ -71,7 +71,7 @@ async fn get_pokemon(req: Request, fetch: Client) -> Response {
 use serde::{Deserialize, Serialize};
 -- use reqwest::Client;
 ++ use reqwest::{Client, StatusCode};
-use tuono_lib::{Props, Request, Response};
+use tuono::{Props, Request, Response};
 
 const ALL_POKEMON: &str = "https://pokeapi.co/api/v2/pokemon?limit=151";
 
@@ -86,7 +86,7 @@ struct Pokemon {
     url: String,
 }
 
-#[tuono_lib::handler]
+#[tuono::handler]
 async fn get_all_pokemons(_req: Request, fetch: Client) -> Response {
     return match fetch.get(ALL_POKEMON).send().await {
         Ok(res) => {

--- a/apps/documentation/src/routes/documentation/tutorial/redirections.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/redirections.mdx
@@ -25,9 +25,9 @@ First, let's create a new route by just creating a new file `/pokemons/GOAT.rs` 
 
 ```rs
 // src/routes/pokemons/GOAT.rs
-use tuono_lib::{Request, Response};
+use tuono::{Request, Response};
 
-#[tuono_lib::handler]
+#[tuono::handler]
 async fn redirect_to_goat(_req: Request) -> Response {
     // Of course the GOAT is mewtwo - feel free to select your favourite 😉
     Response::Redirect("/pokemons/mewtwo".to_string())

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -74,7 +74,7 @@ const NO_HTML_EXTENSIONS: [&str; 1] = ["xml"];
 // TODO: Refine this function to catch
 // if the methods are commented.
 fn read_http_methods_from_file(path: &String) -> Vec<Method> {
-    let regex = Regex::new(r"tuono_lib::api\((.*?)\)]").expect("Failed to create API regex");
+    let regex = Regex::new(r"tuono::api\((.*?)\)]").expect("Failed to create API regex");
 
     let file = fs_extra::file::read_to_string(path).expect("Failed to read API file");
 
@@ -84,7 +84,7 @@ fn read_http_methods_from_file(path: &String) -> Vec<Method> {
             let http_method = proc_macro
                 .as_str()
                 // Extract just the element surrounded by the phrantesist.
-                .replace("tuono_lib::api(", "")
+                .replace("tuono::api(", "")
                 .replace(")]", "");
             Method::from_str(http_method.as_str()).unwrap_or(Method::GET)
         })

--- a/crates/tuono/src/scaffold_project.rs
+++ b/crates/tuono/src/scaffold_project.rs
@@ -1,5 +1,4 @@
 use clap::crate_version;
-use reqwest::blocking;
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::env;
@@ -49,7 +48,7 @@ struct GithubFile {
     element_type: GithubFileType,
 }
 
-fn create_file(path: PathBuf, content: String) -> std::io::Result<()> {
+fn create_file(path: PathBuf, content: String) -> io::Result<()> {
     let mut file = File::create(&path).unwrap_or_else(|err| {
         exit_with_error(&format!(
             "Failed to create file {}: {}",
@@ -71,7 +70,7 @@ pub fn create_new_project(
 
     // In case of missing select the tuono example
     let template = template.unwrap_or("tuono-app".to_string());
-    let client = blocking::Client::builder()
+    let client = Client::builder()
         .user_agent("")
         .build()
         .unwrap_or_else(|_| exit_with_error("Error: Failed to build request client"));
@@ -197,7 +196,7 @@ fn create_directories(
             let path = PathBuf::from(&path.replace(&format!("examples/{template}/"), ""));
 
             let dir_path = folder_path.join(&path);
-            create_dir(&dir_path).unwrap();
+            create_dir(&dir_path)?;
         }
     }
     Ok(())
@@ -229,7 +228,7 @@ fn update_cargo_toml_version(folder_path: &Path) -> io::Result<()> {
     let cargo_toml = fs::read_to_string(&cargo_toml_path)
         .unwrap_or_else(|err| exit_with_error(&format!("Failed to read Cargo.toml: {}", err)));
     let cargo_toml =
-        cargo_toml.replace("{ path = \"../../crates/tuono_lib/\"}", &format!("\"{v}\""));
+        cargo_toml.replace("{ package = \"tuono_lib\", path = \"../../crates/tuono_lib/\"}", &format!("\"{v}\""));
 
     let mut file = OpenOptions::new()
         .write(true)

--- a/crates/tuono/src/scaffold_project.rs
+++ b/crates/tuono/src/scaffold_project.rs
@@ -227,8 +227,10 @@ fn update_cargo_toml_version(folder_path: &Path) -> io::Result<()> {
     let cargo_toml_path = folder_path.join(PathBuf::from("Cargo.toml"));
     let cargo_toml = fs::read_to_string(&cargo_toml_path)
         .unwrap_or_else(|err| exit_with_error(&format!("Failed to read Cargo.toml: {}", err)));
-    let cargo_toml =
-        cargo_toml.replace("{ package = \"tuono_lib\", path = \"../../crates/tuono_lib/\"}", &format!("\"{v}\""));
+    let cargo_toml = cargo_toml.replace(
+        "{ package = \"tuono_lib\", path = \"../../crates/tuono_lib/\"}",
+        &format!("\"{v}\""),
+    );
 
     let mut file = OpenOptions::new()
         .write(true)

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -35,7 +35,7 @@ pub const AXUM_ENTRY_POINT: &str = r##"
 // File automatically generated
 // Do not manually change it
 
-use tuono_lib::{tokio, Mode, Server, axum::Router};
+use tuono::{tokio, Mode, Server, axum::Router};
 // AXUM_GET_ROUTE_HANDLER
 
 const MODE: Mode = /*MODE*/;
@@ -179,7 +179,7 @@ fn generate_axum_source(app: &App, mode: Mode) -> String {
 
     for method in used_http_methods.into_iter() {
         let method = method.to_string().to_lowercase();
-        import_http_handler.push_str(&format!("use tuono_lib::axum::routing::{method};\n"))
+        import_http_handler.push_str(&format!("use tuono::axum::routing::{method};\n"))
     }
 
     src.replace("// AXUM_GET_ROUTE_HANDLER", &import_http_handler)
@@ -228,7 +228,7 @@ mod tests {
         let source_builder = App::new();
 
         let dev_bundle = generate_axum_source(&source_builder, Mode::Dev);
-        assert!(!dev_bundle.contains("use tuono_lib::axum::routing::get;"));
+        assert!(!dev_bundle.contains("use tuono::axum::routing::get;"));
     }
 
     #[test]
@@ -243,6 +243,6 @@ mod tests {
             .insert(String::from("index.rs"), route);
 
         let dev_bundle = generate_axum_source(&source_builder, Mode::Dev);
-        assert!(dev_bundle.contains("use tuono_lib::axum::routing::get;"));
+        assert!(dev_bundle.contains("use tuono::axum::routing::get;"));
     }
 }

--- a/crates/tuono/tests/cli_build.rs
+++ b/crates/tuono/tests/cli_build.rs
@@ -4,8 +4,8 @@ use serial_test::serial;
 use std::fs;
 use utils::TempTuonoProject;
 
-const POST_API_FILE: &str = r"#[tuono_lib::api(POST)]";
-const GET_API_FILE: &str = r"#[tuono_lib::api(GET)]";
+const POST_API_FILE: &str = r"#[tuono::api(POST)]";
+const GET_API_FILE: &str = r"#[tuono::api(GET)]";
 
 #[cfg(target_os = "windows")]
 const BUILD_TUONO_CONFIG: &str = ".\\node_modules\\.bin\\tuono-build-config.cmd";

--- a/examples/tuono-app/Cargo.toml
+++ b/examples/tuono-app/Cargo.toml
@@ -8,6 +8,6 @@ name = "tuono"
 path = ".tuono/main.rs"
 
 [dependencies]
-tuono_lib = { path = "../../crates/tuono_lib/"}
+tuono = { package = "tuono_lib", path = "../../crates/tuono_lib/" }
 serde = { version = "1.0.202", features = ["derive"] }
 

--- a/examples/tuono-app/src/routes/api/health_check.rs
+++ b/examples/tuono-app/src/routes/api/health_check.rs
@@ -1,7 +1,7 @@
-use tuono_lib::Request;
-use tuono_lib::axum::http::StatusCode;
+use tuono::Request;
+use tuono::axum::http::StatusCode;
 
-#[tuono_lib::api(GET)]
+#[tuono::api(GET)]
 pub async fn health_check(_req: Request) -> StatusCode {
     StatusCode::OK
 }

--- a/examples/tuono-app/src/routes/index.rs
+++ b/examples/tuono-app/src/routes/index.rs
@@ -1,12 +1,12 @@
 use serde::Serialize;
-use tuono_lib::{Props, Request, Response};
+use tuono::{Props, Request, Response};
 
 #[derive(Serialize)]
 struct MyResponse<'a> {
     subtitle: &'a str,
 }
 
-#[tuono_lib::handler]
+#[tuono::handler]
 async fn get_server_side_props(_req: Request) -> Response {
     Response::Props(Props::new(MyResponse {
         subtitle: "The react / rust fullstack framework",

--- a/examples/tuono-tutorial/Cargo.toml
+++ b/examples/tuono-tutorial/Cargo.toml
@@ -8,7 +8,7 @@ name = "tuono"
 path = ".tuono/main.rs"
 
 [dependencies]
-tuono_lib = { path = "../../crates/tuono_lib/"}
+tuono = { package = "tuono_lib", path = "../../crates/tuono_lib/" }
 serde = { version = "1.0.202", features = ["derive"] }
 reqwest = "0.12.9"
 

--- a/examples/tuono-tutorial/src/routes/index.rs
+++ b/examples/tuono-tutorial/src/routes/index.rs
@@ -1,7 +1,7 @@
 // src/routes/index.rs
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
-use tuono_lib::{Props, Request, Response};
+use tuono::{Props, Request, Response};
 
 const ALL_POKEMON: &str = "https://pokeapi.co/api/v2/pokemon?limit=151";
 
@@ -16,7 +16,7 @@ struct Pokemon {
     url: String,
 }
 
-#[tuono_lib::handler]
+#[tuono::handler]
 async fn get_all_pokemons(_req: Request, fetch: Client) -> Response {
     match fetch.get(ALL_POKEMON).send().await {
         Ok(res) => {

--- a/examples/tuono-tutorial/src/routes/pokemons/GOAT.rs
+++ b/examples/tuono-tutorial/src/routes/pokemons/GOAT.rs
@@ -1,7 +1,7 @@
 // src/routes/pokemons/GOAT.rs
-use tuono_lib::{Request, Response};
+use tuono::{Request, Response};
 
-#[tuono_lib::handler]
+#[tuono::handler]
 async fn redirect_to_goat(_req: Request) -> Response {
     Response::Redirect("/pokemons/mewtwo".to_string())
 }

--- a/examples/tuono-tutorial/src/routes/pokemons/[pokemon].rs
+++ b/examples/tuono-tutorial/src/routes/pokemons/[pokemon].rs
@@ -1,7 +1,7 @@
 // src/routes/pokemons/[pokemon].rs
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
-use tuono_lib::{Props, Request, Response};
+use tuono::{Props, Request, Response};
 
 const POKEMON_API: &str = "https://pokeapi.co/api/v2/pokemon";
 
@@ -13,7 +13,7 @@ struct Pokemon {
     height: u16,
 }
 
-#[tuono_lib::handler]
+#[tuono::handler]
 async fn get_pokemon(req: Request, fetch: Client) -> Response {
     // The param `pokemon` is defined in the route filename [pokemon].rs
     let pokemon = req.params.get("pokemon").unwrap();

--- a/examples/with-mdx/Cargo.toml
+++ b/examples/with-mdx/Cargo.toml
@@ -8,6 +8,6 @@ name = "tuono"
 path = ".tuono/main.rs"
 
 [dependencies]
-tuono_lib = { path = "../../crates/tuono_lib/"}
+tuono = { package = "tuono_lib", path = "../../crates/tuono_lib/" }
 serde = { version = "1.0.202", features = ["derive"] }
 

--- a/examples/with-tailwind/Cargo.toml
+++ b/examples/with-tailwind/Cargo.toml
@@ -8,4 +8,4 @@ name = "tuono"
 path = ".tuono/main.rs"
 
 [dependencies]
-tuono_lib = { path = "../../crates/tuono_lib/" }
+tuono = { package = "tuono_lib", path = "../../crates/tuono_lib/" }


### PR DESCRIPTION
## Context & Description

Fixes #421.

With this feature, we:

- [x] Update the dependency in each example to
   ```toml
   [dependencies]
   tuono = { package = "tuono_lib", path = "../../crates/tuono_lib/" }
   ```
- [x] Replace each tuono_lib occurrences in the examples with tuono
- [x] Update the tuono CLI to correctly replace the right strings
   - [ ] (add tests)
- [ ] Update tuono_lib_macros to correctly inject the tuono dependency
- [x] Update the documentation