### PR TITLE
docs(configuration): add documentation for `server` option

### DIFF
--- a/apps/documentation/src/routes/documentation/configuration.mdx
+++ b/apps/documentation/src/routes/documentation/configuration.mdx
@@ -58,7 +58,7 @@ Useful for extending vite's functionality
 
 ## server
 
-The following options are only affecting builds served from `tuono dev`.
+The following options configure the server.
 
 ## server.host
 

--- a/apps/documentation/src/routes/documentation/configuration.mdx
+++ b/apps/documentation/src/routes/documentation/configuration.mdx
@@ -55,3 +55,22 @@ Useful for extending vite's functionality
 
 - Type: `Array<Plugin | Array<Plugin> | Promise<Plugin | Array<Plugin>>`
 - [Vite documentation: plugins](https://vite.dev/guide/using-plugins)
+
+## server
+
+The following options are only affecting builds served from `tuono dev`.
+
+## server.host
+
+- Type: `string`
+- Default: `'localhost'`
+
+The hostname or IP address of the server.
+It can be a domain name (e.g., `"example.com"`) or an IP address (e.g., `"127.0.0.1"`)
+
+## server.port
+
+- Type: `number`
+- Default: `3000`
+
+The port number where the server will listen for incoming requests.

--- a/packages/tuono/src/config/types.ts
+++ b/packages/tuono/src/config/types.ts
@@ -1,5 +1,8 @@
 import type { AliasOptions, DepOptimizationOptions, PluginOption } from 'vite'
 
+/**
+ * @see http://tuono.dev/documentation/configuration
+ */
 export interface TuonoConfig {
   server?: {
     host?: string


### PR DESCRIPTION
## Context & Description

Follow-up of
- #407
