### PR TITLE
docs(tutorial): correct api fetching example

### DIFF
--- a/apps/documentation/src/routes/documentation/tutorial/api-fetching.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/api-fetching.mdx
@@ -167,9 +167,9 @@ export default function IndexPage({
         </div>
       </div>
       <ul style={{ flexWrap: 'wrap', display: 'flex', gap: 10 }}>
-        {data.results.map((pokemon) => {
-          return pokemon.name
-        })}
+        {data.results.map((pokemon, i) => (
+          <li key={`${pokemon.name}-${i}`}>{pokemon.name}</li>
+        ))}
       </ul>
     </>
   )


### PR DESCRIPTION
## Context & Description

As per description, a snippet inside tutorial/api-fetching has some invalid code:
each list item wasn't wrapped around a `</li />` element
