### PR TITLE
ci: get documentation `tuono` version automatically

### DIFF
--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -40,8 +40,16 @@ jobs:
       - name: Setup rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      # ⬇️ Keep in sync with `.github/workflows/deploy-documentation.yml`
+      - name: Read tuono version used by the documentation
+        id: get_tuono_version
+        run: |
+          VERSION=$(pnpm ls tuono --filter=documentation | grep "tuono " | sed -E 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Install tuono
-        run: cargo install tuono@0.17.6
+        run: cargo install tuono@${{ steps.get_tuono_version.outputs.version }}
+      # ⬆️
 
       - name: Build project
         working-directory: ./apps/documentation

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy documentation website on AWS S3
+name: Documentation Website Deploy on AWS S3
 
 on:
   push:
@@ -26,8 +26,16 @@ jobs:
       - name: Setup rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      # ⬇️ Keep in sync with `.github/workflows/ci-documentation.yml`
+      - name: Read tuono version used by the documentation
+        id: get_tuono_version
+        run: |
+          VERSION=$(pnpm ls tuono --filter=documentation | grep "tuono " | sed -E 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Install tuono
-        run: cargo install tuono@0.17.6
+        run: cargo install tuono@${{ steps.get_tuono_version.outputs.version }}
+      # ⬆️
 
       - name: Build project
         working-directory: ./apps/documentation


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

None

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

Retrieve tuono version to use when running CI reducing efforts when updating documentation version.

The used command is the following
```sh
pnpm ls tuono --filter=documentation | grep "tuono " | sed -E 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/'
```

#### Command breakdown

```sh
pnpm ls --filter=documentation tuono
```

produces

```text
documentation@0.0.1 /[...]/tuono/apps/documentation (PRIVATE)

dependencies:
tuono 0.17.5
```

---

```sh
grep "tuono "
```

returns

```text
tuono 0.17.5
```
---

```sh
sed -E 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/'
```

clean the previous string by outputting only the semantic version:

```text
0.17.5
```