### PR TITLE
fix: update link component to allow modifier+click to properly work, and write tests

### DIFF
--- a/apps/documentation/src/components/MdxProvider/MdxLink/MdxLink.tsx
+++ b/apps/documentation/src/components/MdxProvider/MdxLink/MdxLink.tsx
@@ -34,7 +34,6 @@ export default function MdxLink(props: MdxLinkProps): JSX.Element {
     <Anchor
       component={Link}
       {...props}
-      target="_blank"
       variant="transparent"
       display="inline"
       style={{ fontWeight: 400 }}

--- a/packages/tuono-router/src/components/Link.spec.tsx
+++ b/packages/tuono-router/src/components/Link.spec.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+
+import Link from './Link'
+
+const pushMock = vi.fn()
+const preloadMock = vi.fn()
+
+vi.mock('../hooks/useRouter', () => ({
+  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+}))
+
+vi.mock('../hooks/useRoute', () => ({
+  useRoute: (): { component: { preload: typeof preloadMock } } => ({
+    component: { preload: preloadMock },
+  }),
+}))
+
+let intersectionObserverCallback: ((inView: boolean) => void) | undefined
+
+vi.mock('react-intersection-observer', () => ({
+  useInView: (options: {
+    onChange: (inView: boolean) => void
+  }): {
+    ref: () => void
+  } => {
+    intersectionObserverCallback = options.onChange
+    return { ref: vi.fn() }
+  },
+}))
+
+describe('Link Component', (): void => {
+  beforeEach((): void => {
+    pushMock.mockReset()
+    preloadMock.mockReset()
+    intersectionObserverCallback = undefined
+  })
+
+  it('renders with correct href and text', (): void => {
+    const { getByRole } = render(<Link href="/test">Test Link</Link>)
+    const link = getByRole('link', { name: 'Test Link' })
+
+    expect(link.getAttribute('href')).toBe('/test')
+    expect(link.textContent).toBe('Test Link')
+  })
+
+  it('calls router.push on normal click', (): void => {
+    const { getByRole } = render(<Link href="/test">Test Link</Link>)
+    const link = getByRole('link')
+
+    fireEvent.click(link)
+    expect(pushMock).toHaveBeenCalledWith('/test', { scroll: true })
+  })
+
+  it('does not navigate if href starts with "#"', (): void => {
+    const { getByRole } = render(<Link href="#section">Anchor Link</Link>)
+    const link = getByRole('link')
+
+    fireEvent.click(link)
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+
+  it('preloads route when in viewport and preload is true', (): void => {
+    render(
+      <Link href="/test" preload={true}>
+        Test Link
+      </Link>,
+    )
+
+    intersectionObserverCallback?.(true)
+    expect(preloadMock).toHaveBeenCalled()
+  })
+
+  it('does not preload route when preload is false', (): void => {
+    render(
+      <Link href="/test" preload={false}>
+        Test Link
+      </Link>,
+    )
+
+    intersectionObserverCallback?.(true)
+    expect(preloadMock).not.toHaveBeenCalled()
+  })
+
+  it('does not call router.push when clicked with a modifier key', (): void => {
+    const { getByRole } = render(<Link href="/test">Test Link</Link>)
+    const link = getByRole('link')
+
+    fireEvent.click(link, { ctrlKey: true })
+    fireEvent.click(link, { metaKey: true })
+    fireEvent.click(link, { shiftKey: true })
+    fireEvent.click(link, { altKey: true })
+
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+
+  it('calls onClick handler when clicked', (): void => {
+    const onClickMock = vi.fn()
+    const { getByRole } = render(
+      <Link href="/test" onClick={onClickMock}>
+        Test Link
+      </Link>,
+    )
+    const link = getByRole('link')
+
+    fireEvent.click(link)
+
+    expect(onClickMock).toHaveBeenCalledTimes(1)
+    expect(pushMock).toHaveBeenCalledWith('/test', { scroll: true })
+  })
+
+  it('calls onClick but does not navigate when clicked with a modifier key', (): void => {
+    const onClickMock = vi.fn()
+    const { getByRole } = render(
+      <Link href="/test" onClick={onClickMock}>
+        Test Link
+      </Link>,
+    )
+    const link = getByRole('link')
+
+    fireEvent.click(link, { ctrlKey: true })
+    fireEvent.click(link, { metaKey: true })
+    fireEvent.click(link, { shiftKey: true })
+    fireEvent.click(link, { altKey: true })
+
+    expect(onClickMock).toHaveBeenCalledTimes(4)
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/tuono-router/src/components/Link.spec.tsx
+++ b/packages/tuono-router/src/components/Link.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 
 import Link from './Link'
 
@@ -29,22 +29,21 @@ vi.mock('react-intersection-observer', () => ({
   },
 }))
 
-describe('Link Component', (): void => {
-  beforeEach((): void => {
+describe('Link Component', () => {
+  beforeEach(() => {
     pushMock.mockReset()
     preloadMock.mockReset()
     intersectionObserverCallback = undefined
   })
 
-  it('renders with correct href and text', (): void => {
-    const { getByRole } = render(<Link href="/test">Test Link</Link>)
-    const link = getByRole('link', { name: 'Test Link' })
+  it('renders with correct href and text', () => {
+    render(<Link href="/test">Test Link</Link>)
+    const link = screen.getByRole('link', { name: 'Test Link' })
 
     expect(link.getAttribute('href')).toBe('/test')
-    expect(link.textContent).toBe('Test Link')
   })
 
-  it('calls router.push on normal click', (): void => {
+  it('calls router.push on normal click', () => {
     const { getByRole } = render(<Link href="/test">Test Link</Link>)
     const link = getByRole('link')
 
@@ -52,7 +51,7 @@ describe('Link Component', (): void => {
     expect(pushMock).toHaveBeenCalledWith('/test', { scroll: true })
   })
 
-  it('does not navigate if href starts with "#"', (): void => {
+  it('does not navigate if href starts with "#"', () => {
     const { getByRole } = render(<Link href="#section">Anchor Link</Link>)
     const link = getByRole('link')
 
@@ -60,7 +59,7 @@ describe('Link Component', (): void => {
     expect(pushMock).not.toHaveBeenCalled()
   })
 
-  it('preloads route when in viewport and preload is true', (): void => {
+  it('preloads route when in viewport and preload is true', () => {
     render(
       <Link href="/test" preload={true}>
         Test Link
@@ -71,7 +70,7 @@ describe('Link Component', (): void => {
     expect(preloadMock).toHaveBeenCalled()
   })
 
-  it('does not preload route when preload is false', (): void => {
+  it('does not preload route when preload is false', () => {
     render(
       <Link href="/test" preload={false}>
         Test Link
@@ -82,7 +81,7 @@ describe('Link Component', (): void => {
     expect(preloadMock).not.toHaveBeenCalled()
   })
 
-  it('does not call router.push when clicked with a modifier key', (): void => {
+  it('does not call router.push when clicked with a modifier key', () => {
     const { getByRole } = render(<Link href="/test">Test Link</Link>)
     const link = getByRole('link')
 
@@ -94,7 +93,7 @@ describe('Link Component', (): void => {
     expect(pushMock).not.toHaveBeenCalled()
   })
 
-  it('calls onClick handler when clicked', (): void => {
+  it('calls onClick handler when clicked', () => {
     const onClickMock = vi.fn()
     const { getByRole } = render(
       <Link href="/test" onClick={onClickMock}>
@@ -109,7 +108,7 @@ describe('Link Component', (): void => {
     expect(pushMock).toHaveBeenCalledWith('/test', { scroll: true })
   })
 
-  it('calls onClick but does not navigate when clicked with a modifier key', (): void => {
+  it('calls onClick but does not navigate when clicked with a modifier key', () => {
     const onClickMock = vi.fn()
     const { getByRole } = render(
       <Link href="/test" onClick={onClickMock}>

--- a/packages/tuono-router/src/components/Link.tsx
+++ b/packages/tuono-router/src/components/Link.tsx
@@ -18,7 +18,9 @@ interface TuonoLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   scroll?: boolean
 }
 
-function isModifiedEvent(event: React.MouseEvent): boolean {
+function isEventModifierKeyActiveAndTargetDifferentFromSelf(
+  event: React.MouseEvent,
+): boolean {
   const eventTarget = event.currentTarget as HTMLAnchorElement | SVGAElement
   const target = eventTarget.getAttribute('target')
   return (
@@ -60,7 +62,7 @@ export default function Link(
       href?.startsWith('#') ||
       // If the user is pressing a modifier key or using the target attribute,
       // we fall back to default behaviour of `a` tag
-      isModifiedEvent(event)
+      isEventModifierKeyActiveAndTargetDifferentFromSelf(event)
     ) {
       return
     }

--- a/packages/tuono-router/src/components/Link.tsx
+++ b/packages/tuono-router/src/components/Link.tsx
@@ -54,13 +54,14 @@ export default function Link(
   const handleTransition: React.MouseEventHandler<HTMLAnchorElement> = (
     event,
   ) => {
+    onClick?.(event)
+
     if (href?.startsWith('#') || isModifiedEvent(event)) {
       // If the user is pressing a modifier key, we fall back to default behaviour of `a` tag
       return
     }
 
     event.preventDefault()
-    onClick?.(event)
 
     router.push(href || '', { scroll })
   }

--- a/packages/tuono-router/src/components/Link.tsx
+++ b/packages/tuono-router/src/components/Link.tsx
@@ -56,8 +56,12 @@ export default function Link(
   ) => {
     onClick?.(event)
 
-    if (href?.startsWith('#') || isModifiedEvent(event)) {
-      // If the user is pressing a modifier key, we fall back to default behaviour of `a` tag
+    if (
+      href?.startsWith('#') ||
+      // If the user is pressing a modifier key or using the target attribute,
+      // we fall back to default behaviour of `a` tag
+      isModifiedEvent(event)
+    ) {
       return
     }
 

--- a/packages/tuono-router/src/components/Link.tsx
+++ b/packages/tuono-router/src/components/Link.tsx
@@ -18,6 +18,18 @@ interface TuonoLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   scroll?: boolean
 }
 
+function isModifiedEvent(event: React.MouseEvent): boolean {
+  const eventTarget = event.currentTarget as HTMLAnchorElement | SVGAElement
+  const target = eventTarget.getAttribute('target')
+  return (
+    (target && target !== '_self') ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey // triggers resource download
+  )
+}
+
 export default function Link(
   componentProps: TuonoLinkProps,
 ): React.JSX.Element {
@@ -42,13 +54,13 @@ export default function Link(
   const handleTransition: React.MouseEventHandler<HTMLAnchorElement> = (
     event,
   ) => {
-    event.preventDefault()
-    onClick?.(event)
-
-    if (href?.startsWith('#')) {
-      window.location.hash = href
+    if (href?.startsWith('#') || isModifiedEvent(event)) {
+      // If the user is pressing a modifier key, we fall back to default behaviour of `a` tag
       return
     }
+
+    event.preventDefault()
+    onClick?.(event)
 
     router.push(href || '', { scroll })
   }

--- a/packages/tuono-router/src/components/Link.tsx
+++ b/packages/tuono-router/src/components/Link.tsx
@@ -19,10 +19,9 @@ interface TuonoLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 }
 
 function isEventModifierKeyActiveAndTargetDifferentFromSelf(
-  event: React.MouseEvent,
+  event: React.MouseEvent<HTMLAnchorElement>,
 ): boolean {
-  const eventTarget = event.currentTarget as HTMLAnchorElement | SVGAElement
-  const target = eventTarget.getAttribute('target')
+  const target = event.currentTarget.getAttribute('target')
   return (
     (target && target !== '_self') ||
     event.metaKey ||


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes #531

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

This PR makes the link fallback to default `a` behaviour when a modifier key is being pressed.

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->
