### PR TITLE
feat: add spinner to 'tuono dev'

### DIFF
--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -31,6 +31,8 @@ serde_json = "1.0"
 fs_extra = "1.3.0"
 http = "1.1.0"
 tuono_internal = {path = "../tuono_internal", version = "0.17.7"}
+spinners = "4.1.1"
+console = "0.15.10"
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/crates/tuono/src/watch.rs
+++ b/crates/tuono/src/watch.rs
@@ -9,6 +9,8 @@ use watchexec_supervisor::job::{start_job, Job};
 
 use crate::mode::Mode;
 use crate::source_builder::bundle_axum_source;
+use console::Term;
+use spinners::{Spinner, Spinners};
 
 #[cfg(target_os = "windows")]
 const DEV_WATCH_BIN_SRC: &str = "node_modules\\.bin\\tuono-dev-watch.cmd";
@@ -35,11 +37,22 @@ fn watch_react_src() -> Job {
     .0
 }
 
-fn build_rust_src() -> Job {
+fn run_rust_dev_server() -> Job {
     start_job(Arc::new(Command {
         program: Program::Exec {
             prog: "cargo".into(),
             args: vec!["run".to_string(), "-q".to_string()],
+        },
+        options: Default::default(),
+    }))
+    .0
+}
+
+fn build_rust_src() -> Job {
+    start_job(Arc::new(Command {
+        program: Program::Exec {
+            prog: "cargo".into(),
+            args: vec!["build".to_string(), "-q".to_string()],
         },
         options: Default::default(),
     }))
@@ -63,17 +76,28 @@ fn build_react_ssr_src() -> Job {
 
 #[tokio::main]
 pub async fn watch() -> Result<()> {
+    let term = Term::stdout();
+    let mut sp = Spinner::new(Spinners::Dots, "Starting dev server...".into());
+
     watch_react_src().start().await;
 
-    let run_server = build_rust_src();
+    let rust_server = run_rust_dev_server();
+    let build_rust_src = build_rust_src();
 
     let build_ssr_bundle = build_react_ssr_src();
 
     build_ssr_bundle.start().await;
+    build_rust_src.start().await;
 
-    run_server.start().await;
-
+    // Wait vite and rust builds
     build_ssr_bundle.to_wait().await;
+    build_rust_src.to_wait().await;
+
+    rust_server.start().await;
+
+    // Remove the spinner
+    sp.stop();
+    term.clear_line().unwrap();
 
     let wx = Watchexec::new(move |mut action| {
         let mut should_reload_ssr_bundle = false;
@@ -95,9 +119,9 @@ pub async fn watch() -> Result<()> {
 
         if should_reload_rust_server {
             println!("  Reloading...");
-            run_server.stop();
+            rust_server.stop();
             bundle_axum_source(Mode::Dev).expect("Failed to bundle rust source");
-            run_server.start();
+            rust_server.start();
         }
 
         if should_reload_ssr_bundle {


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes #285

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->

This PR adds a spinner when the `tuono dev` command starts waiting for the project to build.

> Note. This is just a quick fix. The dev mode will eventually become interactive
