### PR TITLE
feat: polyfill URLSearchParams on the server side

### DIFF
--- a/packages/tuono-router/src/components/RouterContext.tsx
+++ b/packages/tuono-router/src/components/RouterContext.tsx
@@ -31,8 +31,9 @@ function getInitialLocation(
       hash: '',
       href: serverPayloadLocation.href || '',
       searchStr: serverPayloadLocation.searchStr || '',
-      // TODO: Polyfill URLSearchParams
-      search: {},
+      search: Object.fromEntries(
+        new URLSearchParams(serverPayloadLocation.searchStr),
+      ),
     }
   }
 

--- a/packages/tuono/package.json
+++ b/packages/tuono/package.json
@@ -100,6 +100,7 @@
     "fast-text-encoding": "^1.0.6",
     "tuono-fs-router-vite-plugin": "workspace:*",
     "tuono-router": "workspace:*",
+    "url-search-params-polyfill": "^8.2.5",
     "vite": "^5.4.14",
     "web-streams-polyfill": "^4.0.0"
   },

--- a/packages/tuono/src/ssr/server.tsx
+++ b/packages/tuono/src/ssr/server.tsx
@@ -27,6 +27,7 @@
  * https://docs.rs/ssr_rs/latest/ssr_rs/struct.Ssr.html#method.add_global_fn
  */
 import 'fast-text-encoding'
+import 'url-search-params-polyfill'
 
 /* eslint-disable import/order, import/newline-after-import */
 import { MessageChannelPolyfill } from './polyfills/MessageChannel'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       tuono-router:
         specifier: workspace:*
         version: link:../tuono-router
+      url-search-params-polyfill:
+        specifier: ^8.2.5
+        version: 8.2.5
       vite:
         specifier: ^5.4.14
         version: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.1))
@@ -3255,6 +3258,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-search-params-polyfill@8.2.5:
+    resolution: {integrity: sha512-FOEojW4XReTmtZOB7xqSHmJZhrNTmClhBriwLTmle4iA7bwuCo6ldSfbtsFSb8bTf3E0a3XpfonAdaur9vqq8A==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -7019,6 +7025,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-search-params-polyfill@8.2.5: {}
 
   use-callback-ref@1.3.3(@types/react@19.0.8)(react@19.0.0):
     dependencies:


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes #257 

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->

This PR adds the support for URLSearchParams on the server side to allow `useRouter().query` to work on the server side
