### PR TITLE
feat: setup default tracing subscriber

### DIFF
--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -19,6 +19,8 @@ path = "src/lib.rs"
 [dependencies]
 clap = { version = "4.5.4", features = ["derive", "cargo"] }
 watchexec = "5.0.0"
+tracing = "0.1.41"
+tracing-subscriber = {version = "0.3.19", features = ["env-filter"]}
 miette = "7.2.0"
 watchexec-signals = "4.0.0"
 tokio = { version = "1", features = ["full"] }

--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
+use tracing::error;
 use tuono_internal::config::Config;
 
 use crate::route::Route;
@@ -176,15 +177,18 @@ impl App {
 
     pub fn build_react_prod(&self) {
         if !Path::new(BUILD_JS_SCRIPT).exists() {
-            eprintln!("Failed to find the build script. Please run `npm install`");
+            error!("Failed to find the build script. Please run `npm install`");
             std::process::exit(1);
         }
-        let output = Command::new(BUILD_JS_SCRIPT)
-            .output()
-            .expect("Failed to build the react source");
+
+        let output = Command::new(BUILD_JS_SCRIPT).output().unwrap_or_else(|_| {
+            error!("Failed to build the react source");
+            std::process::exit(1);
+        });
+
         if !output.status.success() {
-            eprintln!("Failed to build the react source");
-            eprintln!("Error: {}", String::from_utf8_lossy(&output.stderr));
+            error!("Failed to build the react source");
+            error!("Error: {}", String::from_utf8_lossy(&output.stderr));
             std::process::exit(1);
         }
     }

--- a/crates/tuono/src/build.rs
+++ b/crates/tuono/src/build.rs
@@ -3,24 +3,30 @@ use spinners::{Spinner, Spinners};
 use std::path::PathBuf;
 use std::thread::sleep;
 use std::time::Duration;
+use tracing::{error, trace};
 
 use crate::app::App;
 use crate::mode::Mode;
 
+fn gracefully_exit_with_error(msg: &str) -> ! {
+    error!(msg);
+    std::process::exit(1);
+}
+
 pub fn build(mut app: App, ssg: bool, no_js_emit: bool) {
     if no_js_emit {
         println!("Rust build successfully finished");
-        return;
+        std::process::exit(0);
     }
 
     if ssg && app.has_dynamic_routes() {
         // TODO: allow dynamic routes static generation
         println!("Cannot statically build dynamic routes");
-        return;
+        std::process::exit(1);
     }
 
     app.build_tuono_config()
-        .expect("Failed to build tuono.config.ts");
+        .unwrap_or_else(|_| gracefully_exit_with_error("Failed to build tuono.config.ts"));
 
     let mut app_build_spinner = Spinner::new(Spinners::Dots, "Building app...".into());
 
@@ -38,41 +44,58 @@ pub fn build(mut app: App, ssg: bool, no_js_emit: bool) {
         let static_dir = PathBuf::from("out/static");
 
         if static_dir.is_dir() {
-            std::fs::remove_dir_all(&static_dir).expect("Failed to clear the out/static folder");
+            std::fs::remove_dir_all(&static_dir).unwrap_or_else(|_| {
+                gracefully_exit_with_error("Failed to clear the out/static folder")
+            });
         }
 
-        std::fs::create_dir(&static_dir).expect("Failed to create static output dir");
+        std::fs::create_dir(&static_dir)
+            .unwrap_or_else(|_| gracefully_exit_with_error("Failed to create static output dir"));
 
         copy(
             "./out/client",
             static_dir,
             &CopyOptions::new().overwrite(true).content_only(true),
         )
-        .expect("Failed to clone assets into static output folder");
+        .unwrap_or_else(|_| {
+            gracefully_exit_with_error("Failed to clone assets into static output folder")
+        });
 
         // Start the server
         #[allow(clippy::zombie_processes)]
         let mut rust_server = app.run_rust_server();
 
+        let mut exit_and_shut_server = |msg: &str| -> ! {
+            _ = rust_server.kill();
+            gracefully_exit_with_error(msg)
+        };
+
         let reqwest_client = reqwest::blocking::Client::builder()
             .user_agent("")
             .build()
-            .expect("Failed to build reqwest client");
+            .unwrap_or_else(|_| exit_and_shut_server("Failed to build reqwest client"));
 
         // Wait for server
         let mut is_server_ready = false;
         let config = app.config.as_ref().unwrap();
 
         while !is_server_ready {
+            trace!("Checking server availability");
             let server_url = format!("http://{}:{}", config.server.host, config.server.port);
             if reqwest_client.get(&server_url).send().is_ok() {
                 is_server_ready = true;
+            } else {
+                trace!("Server not ready yet. Sleeping for 1 second");
             }
             sleep(Duration::from_secs(1));
         }
 
+        trace!("Server is ready, starting static site generation");
+
         for (_, route) in app.route_map {
-            route.save_ssg_file(&reqwest_client);
+            if let Err(msg) = route.save_ssg_file(&reqwest_client) {
+                exit_and_shut_server(&msg);
+            }
         }
 
         // Close server

--- a/crates/tuono/src/cli.rs
+++ b/crates/tuono/src/cli.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use tracing::{debug, span, Level};
+use tracing::{span, Level};
 use tracing_subscriber::EnvFilter;
 
 use crate::app::App;
@@ -73,7 +73,7 @@ pub fn app() -> std::io::Result<()> {
 
     match args.action {
         Actions::Dev => {
-            let span = span!(Level::DEBUG, "DEV");
+            let span = span!(Level::TRACE, "DEV");
 
             let _guard = span.enter();
 
@@ -87,7 +87,7 @@ pub fn app() -> std::io::Result<()> {
             watch::watch().unwrap();
         }
         Actions::Build { ssg, no_js_emit } => {
-            let span = span!(Level::DEBUG, "BUILD");
+            let span = span!(Level::TRACE, "BUILD");
 
             let _guard = span.enter();
 
@@ -100,7 +100,7 @@ pub fn app() -> std::io::Result<()> {
             template,
             head,
         } => {
-            let span = span!(Level::DEBUG, "NEW");
+            let span = span!(Level::TRACE, "NEW");
 
             let _guard = span.enter();
 

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -189,7 +189,7 @@ impl Route {
         if self.axum_info.is_some() {
             trace!("The route is an axum route, saving the JSON file");
 
-            let data_file_path = PathBuf::from(&format!("out/static/__tuono/data{path}"));
+            let data_file_path = PathBuf::from(&format!("out/static/__tuono/data{path}.json"));
 
             let data_parent_dir = match data_file_path.parent() {
                 Some(parent_dir) => parent_dir,

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -143,6 +143,10 @@ impl Route {
     }
 
     pub fn save_ssg_file(&self, reqwest: &Client) -> Result<(), String> {
+        if self.is_api() {
+            return Ok(());
+        }
+
         let path = &self.path.replace("index", "");
 
         let url = format!("http://localhost:3000{path}");
@@ -165,13 +169,11 @@ impl Route {
             }
         };
 
-        if !parent_dir.is_dir() {
-            if let Err(_) = create_all(parent_dir, false) {
-                return Err(format!(
-                    "Failed to create the parent directory {:?}",
-                    parent_dir
-                ));
-            }
+        if !parent_dir.is_dir() || create_all(parent_dir, false).is_err() {
+            return Err(format!(
+                "Failed to create the parent directory {:?}",
+                parent_dir
+            ));
         }
 
         trace!("Saving the HTML file: {:?}", file_path);
@@ -181,7 +183,7 @@ impl Route {
             Err(_) => return Err(format!("Failed to create the file: {:?}", file_path)),
         };
 
-        if let Err(_) = io::copy(&mut response, &mut file) {
+        if io::copy(&mut response, &mut file).is_err() {
             return Err(format!("Failed to write the file: {:?}", file_path));
         }
 
@@ -201,13 +203,11 @@ impl Route {
                 }
             };
 
-            if !data_parent_dir.is_dir() {
-                if let Err(_) = create_all(data_parent_dir, false) {
-                    return Err(format!(
-                        "Failed to create the parent directory {:?}",
-                        data_parent_dir
-                    ));
-                }
+            if !data_parent_dir.is_dir() && create_all(data_parent_dir, false).is_err() {
+                return Err(format!(
+                    "Failed to create the parent directory {:?}",
+                    data_parent_dir
+                ));
             }
 
             let base = Url::parse("http://localhost:3000/__tuono/data").unwrap();
@@ -240,8 +240,8 @@ impl Route {
                 }
             };
 
-            if let Err(_) = io::copy(&mut response, &mut data_file) {
-                return Err(format!("Failed to write the JSON file"));
+            if io::copy(&mut response, &mut data_file).is_err() {
+                return Err("Failed to write the JSON file".to_string());
             }
         }
 

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io;
 use std::path::PathBuf;
 use std::str::FromStr;
+use tracing::trace;
 
 fn has_dynamic_path(route: &str) -> bool {
     let regex = Regex::new(r"\[(.*?)\]").expect("Failed to create the regex");
@@ -141,35 +142,72 @@ impl Route {
         self.axum_info = Some(AxumInfo::new(self))
     }
 
-    pub fn save_ssg_file(&self, reqwest: &Client) {
+    pub fn save_ssg_file(&self, reqwest: &Client) -> Result<(), String> {
         let path = &self.path.replace("index", "");
 
-        let mut response = reqwest
-            .get(format!("http://localhost:3000{path}"))
-            .send()
-            .unwrap();
+        let url = format!("http://localhost:3000{path}");
+
+        trace!("Requesting the page: {}", url);
+        let mut response = match reqwest.get(format!("http://localhost:3000{path}")).send() {
+            Ok(response) => response,
+            Err(_) => return Err(format!("Failed to get the response: {}", url)),
+        };
 
         let file_path = self.output_file_path();
 
-        let parent_dir = file_path.parent().unwrap();
+        let parent_dir = match file_path.parent() {
+            Some(parent_dir) => parent_dir,
+            None => {
+                return Err(format!(
+                    "Failed to get the parent directory {:?}",
+                    file_path
+                ))
+            }
+        };
 
         if !parent_dir.is_dir() {
-            create_all(parent_dir, false).expect("Failed to create parent directories");
+            if let Err(_) = create_all(parent_dir, false) {
+                return Err(format!(
+                    "Failed to create the parent directory {:?}",
+                    parent_dir
+                ));
+            }
         }
 
-        let mut file = File::create(file_path).expect("Failed to create the HTML file");
+        trace!("Saving the HTML file: {:?}", file_path);
 
-        io::copy(&mut response, &mut file).expect("Failed to write the HTML on the file");
+        let mut file = match File::create(&file_path) {
+            Ok(file) => file,
+            Err(_) => return Err(format!("Failed to create the file: {:?}", file_path)),
+        };
+
+        if let Err(_) = io::copy(&mut response, &mut file) {
+            return Err(format!("Failed to write the file: {:?}", file_path));
+        }
 
         // Saving also the server response
         if self.axum_info.is_some() {
+            trace!("The route is an axum route, saving the JSON file");
+
             let data_file_path = PathBuf::from(&format!("out/static/__tuono/data{path}"));
 
-            let data_parent_dir = data_file_path.parent().unwrap();
+            let data_parent_dir = match data_file_path.parent() {
+                Some(parent_dir) => parent_dir,
+                None => {
+                    return Err(format!(
+                        "Failed to get the parent directory {:?}",
+                        data_file_path
+                    ))
+                }
+            };
 
             if !data_parent_dir.is_dir() {
-                create_all(data_parent_dir, false)
-                    .expect("Failed to create data parent directories");
+                if let Err(_) = create_all(data_parent_dir, false) {
+                    return Err(format!(
+                        "Failed to create the parent directory {:?}",
+                        data_parent_dir
+                    ));
+                }
             }
 
             let base = Url::parse("http://localhost:3000/__tuono/data").unwrap();
@@ -182,13 +220,32 @@ impl Route {
                 .join(pathname)
                 .expect("Failed to build the reqwest URL");
 
-            let mut response = reqwest.get(url).send().unwrap();
+            trace!("Requesting the JSON file: {}", url);
 
-            let mut data_file =
-                File::create(data_file_path).expect("Failed to create the JSON file");
+            let mut response = match reqwest.get(url.clone()).send() {
+                Ok(response) => {
+                    trace!("Successfully got the response for: {url}");
+                    response
+                }
+                Err(_) => return Err(format!("Failed to get the response: {url}")),
+            };
 
-            io::copy(&mut response, &mut data_file).expect("Failed to write the JSON on the file");
+            let mut data_file = match File::create(&data_file_path) {
+                Ok(file) => file,
+                Err(_) => {
+                    return Err(format!(
+                        "Failed to create the JSON file: {:?}",
+                        data_file_path
+                    ))
+                }
+            };
+
+            if let Err(_) = io::copy(&mut response, &mut data_file) {
+                return Err(format!("Failed to write the JSON file"));
+            }
         }
+
+        Ok(())
     }
 
     fn output_file_path(&self) -> PathBuf {


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes #563 

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->

Overall improvement to the CLI logging system.

This PR also fixes a couple of issue related to the `--static` build. This logging system will help understand future compilation bugs.

#### Usage:

```sh
RUST_LOG=trace (any tuono command)
```

This command will log all the event from Level `trace` to the most critical.

Note: all the `error` even will always be triggered.

For this feature I used this amazing crate -> https://docs.rs/tracing/latest/tracing/