### PR TITLE
test(packages/tuono): `create-json-config` test are not clearing `writeFileSpy` mock

### DIFF
--- a/packages/tuono/src/build/config/create-json-config.spec.ts
+++ b/packages/tuono/src/build/config/create-json-config.spec.ts
@@ -1,6 +1,6 @@
 import fs from 'fs/promises'
 
-import { describe, expect, it, vitest } from 'vitest'
+import { beforeEach, describe, expect, it, vitest } from 'vitest'
 import react from '@vitejs/plugin-react-swc'
 
 import { createJsonConfig } from './create-json-config'
@@ -8,6 +8,10 @@ import { createJsonConfig } from './create-json-config'
 const writeFileSpy = vitest.spyOn(fs, 'writeFile').mockResolvedValue(void 0)
 
 describe('createJsonConfig', () => {
+  beforeEach(() => {
+    writeFileSpy.mockClear()
+  })
+
   const sampleConfig = { server: { host: 'h', port: 1 } }
 
   it('should process config with only server property', async () => {


### PR DESCRIPTION


<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes https://github.com/tuono-labs/tuono/pull/582#discussion_r1966796341

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

`writeFileSpy` should be cleared before each test.

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->
