### PR TITLE
feat: allow custom route with `.txt` extension

### DIFF
--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -70,7 +70,7 @@ impl AxumInfo {
 }
 
 // TODO: to be extended with common scenarios
-const NO_HTML_EXTENSIONS: [&str; 1] = ["xml"];
+const NO_HTML_EXTENSIONS: [&str; 2] = ["xml", "txt"];
 
 // TODO: Refine this function to catch
 // if the methods are commented.
@@ -306,6 +306,7 @@ mod tests {
             ("/index", "out/static/index.html"),
             ("/documentation", "out/static/documentation/index.html"),
             ("/sitemap.xml", "out/static/sitemap.xml"),
+            ("/robot.txt", "out/static/robot.txt"),
             (
                 "/documentation/routing",
                 "out/static/documentation/routing/index.html",


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes None

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->

Since the need of creating a `robot.txt` file in the documentation (https://github.com/tuono-labs/tuono-documentation/issues/28), we add here the filter of extensions that allow custom endpoints.


