### PR TITLE
feat(packages/tuono-router): add `replace` method to router and `replace` prop to `Link`

### DIFF
--- a/packages/tuono-router/src/components/Link.spec.tsx
+++ b/packages/tuono-router/src/components/Link.spec.tsx
@@ -4,10 +4,14 @@ import { render, fireEvent, screen } from '@testing-library/react'
 import Link from './Link'
 
 const pushMock = vi.fn()
+const replaceMock = vi.fn()
 const preloadMock = vi.fn()
 
 vi.mock('../hooks/useRouter', () => ({
-  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+  useRouter: (): { push: typeof pushMock; replace: typeof replaceMock } => ({
+    push: pushMock,
+    replace: replaceMock,
+  }),
 }))
 
 vi.mock('../hooks/useRoute', () => ({
@@ -49,6 +53,19 @@ describe('Link Component', () => {
 
     fireEvent.click(link)
     expect(pushMock).toHaveBeenCalledWith('/test', { scroll: true })
+  })
+
+  it('calls router.replace on normal click when replace prop is true', () => {
+    render(
+      <Link href="/test" replace>
+        Test Link
+      </Link>,
+    )
+    const link = screen.getByRole('link')
+
+    fireEvent.click(link)
+    expect(replaceMock).toHaveBeenCalledWith('/test', { scroll: true })
+    expect(pushMock).not.toHaveBeenCalled()
   })
 
   it('does not navigate if href starts with "#"', () => {

--- a/packages/tuono-router/src/components/Link.spec.tsx
+++ b/packages/tuono-router/src/components/Link.spec.tsx
@@ -55,7 +55,7 @@ describe('Link Component', () => {
     expect(pushMock).toHaveBeenCalledWith('/test', { scroll: true })
   })
 
-  it('calls router.replace on normal click when replace prop is true', () => {
+  it('calls router.replace on click when the replace prop is true', () => {
     render(
       <Link href="/test" replace>
         Test Link

--- a/packages/tuono-router/src/components/Link.tsx
+++ b/packages/tuono-router/src/components/Link.tsx
@@ -75,7 +75,9 @@ export default function Link(
 
     event.preventDefault()
 
-    router[replace ? 'replace' : 'push'](href || '', { scroll })
+    const method = replace ? 'replace' : 'push'
+
+    router[method](href || '', { scroll })
   }
 
   return (

--- a/packages/tuono-router/src/components/Link.tsx
+++ b/packages/tuono-router/src/components/Link.tsx
@@ -16,6 +16,12 @@ interface TuonoLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
    * @default true
    */
   scroll?: boolean
+
+  /**
+   * If "true" the history entry will be replaced instead of pushed.
+   * @default false
+   */
+  replace?: boolean
 }
 
 function isEventModifierKeyActiveAndTargetDifferentFromSelf(
@@ -39,6 +45,7 @@ export default function Link(
     scroll = true,
     children,
     href,
+    replace,
     onClick,
     ...rest
   } = componentProps
@@ -68,7 +75,7 @@ export default function Link(
 
     event.preventDefault()
 
-    router.push(href || '', { scroll })
+    router[replace ? 'replace' : 'push'](href || '', { scroll })
   }
 
   return (

--- a/packages/tuono-router/src/hooks/useRouter.ts
+++ b/packages/tuono-router/src/hooks/useRouter.ts
@@ -3,8 +3,9 @@ import React from 'react'
 import { useRouterContext } from '../components/RouterContext'
 
 type NavigationType = 'pushState' | 'replaceState'
+type NavigationFn = (path: string, opts?: NavigationOptions) => void
 
-interface NavigateOptions {
+interface NavigationOptions {
   /**
    * If "false" the scroll offset will be kept across page navigation. Default "true"
    */
@@ -15,13 +16,13 @@ interface UseRouterResult {
   /**
    * Redirects to the path passed as argument updating the browser history.
    */
-  push: (path: string, opt?: NavigateOptions) => void
+  push: NavigationFn
 
   /**
    * Redirects to the path passed as argument replacing the current history
    * entry.
    */
-  replace: (path: string, opt?: NavigateOptions) => void
+  replace: NavigationFn
 
   /**
    * This object contains all the query params of the current route
@@ -38,8 +39,8 @@ export const useRouter = (): UseRouterResult => {
   const { location, updateLocation } = useRouterContext()
 
   const navigate = React.useCallback(
-    (type: NavigationType, path: string, opt?: NavigateOptions): void => {
-      const { scroll = true } = opt || {}
+    (type: NavigationType, path: string, opts?: NavigationOptions): void => {
+      const { scroll = true } = opts || {}
       const url = new URL(path, window.location.origin)
 
       updateLocation({
@@ -60,15 +61,15 @@ export const useRouter = (): UseRouterResult => {
   )
 
   const push = React.useCallback(
-    (path: string, opt?: NavigateOptions): void => {
-      navigate('pushState', path, opt)
+    (path: string, opts?: NavigationOptions): void => {
+      navigate('pushState', path, opts)
     },
     [navigate],
   )
 
   const replace = React.useCallback(
-    (path: string, opt?: NavigateOptions): void => {
-      navigate('replaceState', path, opt)
+    (path: string, opts?: NavigationOptions): void => {
+      navigate('replaceState', path, opts)
     },
     [navigate],
   )

--- a/packages/tuono-router/src/hooks/useRouter.ts
+++ b/packages/tuono-router/src/hooks/useRouter.ts
@@ -2,7 +2,9 @@ import React from 'react'
 
 import { useRouterContext } from '../components/RouterContext'
 
-interface PushOptions {
+type NavigationType = 'pushState' | 'replaceState'
+
+interface NavigateOptions {
   /**
    * If "false" the scroll offset will be kept across page navigation. Default "true"
    */
@@ -13,7 +15,13 @@ interface UseRouterResult {
   /**
    * Redirects to the path passed as argument updating the browser history.
    */
-  push: (path: string, opt?: PushOptions) => void
+  push: (path: string, opt?: NavigateOptions) => void
+
+  /**
+   * Redirects to the path passed as argument replacing the current history
+   * entry.
+   */
+  replace: (path: string, opt?: NavigateOptions) => void
 
   /**
    * This object contains all the query params of the current route
@@ -29,8 +37,8 @@ interface UseRouterResult {
 export const useRouter = (): UseRouterResult => {
   const { location, updateLocation } = useRouterContext()
 
-  const push = React.useCallback(
-    (path: string, opt?: PushOptions): void => {
+  const navigate = React.useCallback(
+    (type: NavigationType, path: string, opt?: NavigateOptions): void => {
       const { scroll = true } = opt || {}
       const url = new URL(path, window.location.origin)
 
@@ -41,7 +49,8 @@ export const useRouter = (): UseRouterResult => {
         searchStr: url.search,
         hash: url.hash,
       })
-      history.pushState(path, '', path)
+
+      history[type](path, '', path)
 
       if (scroll) {
         window.scroll(0, 0)
@@ -50,8 +59,23 @@ export const useRouter = (): UseRouterResult => {
     [updateLocation],
   )
 
+  const push = React.useCallback(
+    (path: string, opt?: NavigateOptions): void => {
+      navigate('pushState', path, opt)
+    },
+    [navigate],
+  )
+
+  const replace = React.useCallback(
+    (path: string, opt?: NavigateOptions): void => {
+      navigate('replaceState', path, opt)
+    },
+    [navigate],
+  )
+
   return {
     push,
+    replace,
     query: location.search,
     pathname: location.pathname,
   }


### PR DESCRIPTION
### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes https://github.com/tuono-labs/tuono/issues/537

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

This PR does the following:
- add `replace` method to the instance returned by `useRouter` hook
- slightly refactor inner `useRouter` types to avoid repetition with adding `replace` method
- add `replace` prop to `Link` component that replaces the state by calling router's now added `replace` method

Related docs will be added with https://github.com/tuono-labs/tuono-documentation/pull/30
