### PR TITLE
fix(examples/tuono-tutorial): use pokemon name as key instead of index

### DIFF
--- a/examples/tuono-tutorial/src/routes/index.tsx
+++ b/examples/tuono-tutorial/src/routes/index.tsx
@@ -46,7 +46,7 @@ export default function IndexPage({
         <PokemonLink name="GOAT" id={0} />
 
         {data.results.map((pokemon, i) => (
-          <PokemonLink key={i + 1} name={pokemon.name} id={i + 1} />
+          <PokemonLink key={pokemon.name} name={pokemon.name} id={i + 1} />
         ))}
       </ul>
     </>


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes #612

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

Use `pokemon.name` as key in the pokemon list page.
I also checked other improper usages of `key` prop in the repo, I haven't found any so far

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->
