### PR TITLE
test(packages/tuono-router): improve test using mocks

### DIFF
--- a/packages/tuono-router/src/components/Link.spec.tsx
+++ b/packages/tuono-router/src/components/Link.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, fireEvent, screen } from '@testing-library/react'
+import { render, fireEvent, screen, cleanup } from '@testing-library/react'
 
 import { Link } from './Link'
 
@@ -33,8 +33,9 @@ vi.mock('react-intersection-observer', () => ({
   },
 }))
 
-describe('Link component', () => {
+describe('<Link />', () => {
   beforeEach(() => {
+    cleanup()
     pushMock.mockReset()
     preloadMock.mockReset()
     intersectionObserverCallback = undefined

--- a/packages/tuono-router/src/components/NotFound.spec.tsx
+++ b/packages/tuono-router/src/components/NotFound.spec.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { JSX, ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render } from '@testing-library/react'
 
@@ -28,17 +28,22 @@ const useRouterContextMock = vi.mocked(useRouterContext as () => RouterMock)
 const RouteMatchMock = vi.mocked(RouteMatch)
 const NotFoundDefaultContentMock = vi.mocked(NotFoundDefaultContent)
 
+const rootRouteComponentMock = vi
+  .fn<(props: { children: ReactNode }) => JSX.Element>()
+  .mockImplementation(({ children }) => <div>{children}</div>)
+
+const root = new Route({
+  isRoot: true,
+  component: rootRouteComponentMock as unknown as RouteComponent,
+})
+
 describe('<NotFound />', () => {
   afterEach(() => {
     cleanup()
-    vi.resetAllMocks()
-  })
-
-  const root = new Route({
-    isRoot: true,
-    component: (({ children }: { children: ReactNode }) => (
-      <div>{children}</div>
-    )) as unknown as RouteComponent,
+    useRouterContextMock.mockReset()
+    RouteMatchMock.mockReset()
+    NotFoundDefaultContentMock.mockReset()
+    rootRouteComponentMock.mockClear()
   })
 
   describe('when a custom 404 page exists', () => {
@@ -63,6 +68,7 @@ describe('<NotFound />', () => {
         { route: customRoute404, serverInitialData: {} },
         undefined, // deprecated react context parameter
       )
+      expect(rootRouteComponentMock).not.toHaveBeenCalled()
       expect(NotFoundDefaultContentMock).not.toHaveBeenCalled()
     })
   })
@@ -80,6 +86,7 @@ describe('<NotFound />', () => {
       render(<NotFound />)
 
       expect(RouteMatchMock).not.toHaveBeenCalled()
+      expect(rootRouteComponentMock).toHaveBeenCalled()
       expect(NotFoundDefaultContentMock).toHaveBeenCalledOnce()
     })
   })

--- a/packages/tuono-router/src/components/NotFound.spec.tsx
+++ b/packages/tuono-router/src/components/NotFound.spec.tsx
@@ -1,11 +1,9 @@
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-
 import { cleanup, render } from '@testing-library/react'
 
 import { Route } from '../route'
 import type { RouteComponent } from '../types'
-
 import type { RouterInstanceType } from '../router'
 
 import { NotFound } from './NotFound'

--- a/packages/tuono-router/src/components/NotFound.tsx
+++ b/packages/tuono-router/src/components/NotFound.tsx
@@ -4,7 +4,7 @@ import { useRouterContext } from '../components/RouterContext'
 import { ROOT_ROUTE_ID } from '../route'
 
 import { RouteMatch } from './RouteMatch'
-import { Link } from './Link'
+import { NotFoundDefaultContent } from './NotFoundDefaultContent'
 
 export function NotFound(): JSX.Element | null {
   const { router } = useRouterContext()
@@ -22,8 +22,7 @@ export function NotFound(): JSX.Element | null {
 
   return (
     <RootLayout data={null} isLoading={false}>
-      <h1>404 Not found</h1>
-      <Link href="/">Return home</Link>
+      <NotFoundDefaultContent />
     </RootLayout>
   )
 }

--- a/packages/tuono-router/src/components/NotFoundDefaultContent.tsx
+++ b/packages/tuono-router/src/components/NotFoundDefaultContent.tsx
@@ -1,0 +1,12 @@
+import type { JSX } from 'react'
+
+import { Link } from './Link'
+
+export function NotFoundDefaultContent(): JSX.Element {
+  return (
+    <>
+      <h1>Page Not Found</h1>
+      <Link href="/">Return to Homepage</Link>
+    </>
+  )
+}

--- a/packages/tuono-router/src/components/RouteMatch.spec.tsx
+++ b/packages/tuono-router/src/components/RouteMatch.spec.tsx
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-
 import { cleanup, render, screen } from '@testing-library/react'
 
 import { Route } from '../route'

--- a/packages/tuono-router/src/components/RouteMatch.spec.tsx
+++ b/packages/tuono-router/src/components/RouteMatch.spec.tsx
@@ -1,18 +1,23 @@
-import type { JSX } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { cleanup, render, screen } from '@testing-library/react'
 
 import { Route } from '../route'
 import type { RouteComponent, RouteProps } from '../types'
+import { useServerPayloadData } from '../hooks/useServerPayloadData'
 
 import { RouteMatch } from './RouteMatch'
 
 function createRouteComponent(
   routeType: string,
-  RouteComponentFn: (props: RouteProps) => JSX.Element,
+  includeChildren: boolean,
 ): RouteComponent {
-  const RootComponent = RouteComponentFn as RouteComponent
+  const RootComponent = (({ children }: RouteProps) => (
+    <div data-testid={routeType}>
+      {`${routeType} route`}
+      {includeChildren ? children : null}
+    </div>
+  )) as RouteComponent
   RootComponent.preload = vi.fn()
   RootComponent.displayName = routeType
   return RootComponent
@@ -20,35 +25,28 @@ function createRouteComponent(
 
 const root = new Route({
   isRoot: true,
-  component: createRouteComponent('root', ({ children }) => (
-    <div data-testid="root">root route {children}</div>
-  )),
+  component: createRouteComponent('root', true),
 })
 
 const parent = new Route({
-  component: createRouteComponent('parent', ({ children }) => (
-    <div data-testid="parent">parent route {children}</div>
-  )),
+  component: createRouteComponent('parent', true),
   getParentRoute: (): Route => root,
 })
 
 const route = new Route({
-  component: createRouteComponent('route', () => (
-    <p data-testid="route">current route</p>
-  )),
+  component: createRouteComponent('current', false),
   getParentRoute: (): Route => parent,
 })
 
-vi.mock('../hooks/useServerPayloadData.ts', () => ({
-  useServerPayloadData: (): { data: unknown; isLoading: boolean } => {
-    return {
-      data: undefined,
-      isLoading: false,
-    }
-  },
+vi.mock('../hooks/useServerPayloadData', () => ({
+  useServerPayloadData: vi.fn(),
 }))
+vi.mocked(useServerPayloadData).mockReturnValue({
+  data: undefined,
+  isLoading: false,
+})
 
-describe('Test RouteMatch component', () => {
+describe('<RouteMatch />', () => {
   afterEach(cleanup)
 
   it('should correctly render nested routes', () => {
@@ -59,26 +57,19 @@ describe('Test RouteMatch component', () => {
       <div
         data-testid="root"
       >
-        root route 
+        root route
         <div
           data-testid="parent"
         >
-          parent route 
-          <p
-            data-testid="route"
+          parent route
+          <div
+            data-testid="current"
           >
             current route
-          </p>
+          </div>
         </div>
       </div>
     `,
     )
-    expect(screen.getByTestId('route')).toMatchInlineSnapshot(`
-      <p
-        data-testid="route"
-      >
-        current route
-      </p>
-    `)
   })
 })

--- a/packages/tuono-router/src/hooks/useRoute.spec.ts
+++ b/packages/tuono-router/src/hooks/useRoute.spec.ts
@@ -1,19 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
+import { useRouterContext } from '../components/RouterContext'
+
 import { useRoute } from './useRoute'
 
-const { useRouterContextMock } = vi.hoisted(() => ({
-  useRouterContextMock: vi.fn<
-    () => {
-      router: { routesById: Record<string, { id: string }> }
-    }
-  >(),
+vi.mock('../components/RouterContext.tsx', () => ({
+  useRouterContext: vi.fn(),
 }))
 
-vi.mock('../components/RouterContext.tsx', () => ({
-  useRouterContext: useRouterContextMock,
-}))
+interface RouterMock {
+  router: { routesById: Record<string, { id: string }> }
+}
+const useRouterContextMock = vi.mocked(useRouterContext as () => RouterMock)
 
 describe('useRoute', () => {
   afterEach(() => {


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Follow up of https://github.com/tuono-labs/tuono/pull/633#pullrequestreview-2669394172

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

- uniform comonent style title ("Test ComponentName Component" → "< ComponentName />") 
- `packages/tuono-router/src/components/Link.spec.tsx`
  - add missing `cleanup` function 
- `packages/tuono-router/src/components/NotFound.spec.tsx`
  - use `vi.mocked` instead of mock + `vi.hoised`
  - mock components and hooks directly used by `NotFound.spec.tsx` 
  - replaced snapshots checks with mock checks to ensure component is working correctly
  - In order to have a consistent test system checks I created `NotFoundDefaultContent` instead of using snapshots or rtl checks
- `packages/tuono-router/src/components/RouteMatch.spec.tsx`
  - simplify `createRouteComponent` function
- `packages/tuono-router/src/hooks/useRoute.spec.ts`
  - use `vi.mocked` instead of mock + `vi.hoised`
  - remove redundant check on current route
