### PR TITLE
feat: allow for custom server logic

### DIFF
--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -40,6 +40,7 @@ pub struct App {
     pub route_map: HashMap<String, Route>,
     pub base_path: PathBuf,
     pub has_app_state: bool,
+    pub has_server: bool,
     pub config: Option<Config>,
 }
 
@@ -51,6 +52,14 @@ fn has_app_state(base_path: PathBuf) -> std::io::Result<bool> {
     Ok(contents.contains("pub fn main"))
 }
 
+fn has_server(base_path: PathBuf) -> std::io::Result<bool> {
+    let file = File::open(base_path.join("src/server.rs"))?;
+    let mut buf_reader = BufReader::new(file);
+    let mut contents = String::new();
+    buf_reader.read_to_string(&mut contents)?;
+    Ok(contents.contains("pub async fn main"))
+}
+
 impl App {
     pub fn new() -> Self {
         let base_path = std::env::current_dir().expect("Failed to read current_dir");
@@ -58,7 +67,8 @@ impl App {
         let mut app = App {
             route_map: HashMap::new(),
             base_path: base_path.clone(),
-            has_app_state: has_app_state(base_path).unwrap_or(false),
+            has_app_state: has_app_state(base_path.to_owned()).unwrap_or(false),
+            has_server: has_server(base_path).unwrap_or(false),
             config: None,
         };
 
@@ -253,7 +263,6 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]

--- a/crates/tuono/templates/server.rs
+++ b/crates/tuono/templates/server.rs
@@ -8,7 +8,8 @@ const MODE: Mode = /*MODE*/;
 
 // MODULE_IMPORTS
 
-//MAIN_FILE_IMPORT//
+//APP_STATE_IMPORT//
+//SERVER_IMPORT//
 
 #[tokio::main]
 async fn main() {
@@ -18,12 +19,14 @@ async fn main() {
         println!("\n  ⚡ Tuono v/*VERSION*/");
     }
 
-    //MAIN_FILE_DEFINITION//
+    //APP_STATE_DEFINITION//
 
     let router = Router::new()
         // ROUTE_BUILDER
-        //MAIN_FILE_USAGE//;
+        //APP_STATE_USAGE//;
 
-    Server::init(router, MODE).await.start().await
+    //SERVER_DEFINITION//
+
+    Server::init(router, MODE, serve).await.start().await
 }
 


### PR DESCRIPTION
Replaced `TcpListener` with a generic `serve` function to allow more flexibility in server initialization. Updated `App` and template logic to detect and configure server functionality dynamically. This change enhances modularity and simplifies future extensions.

### Checklist

- [X] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Partially addresses #753 

### Overview

This change adds the ability to specify custom serve logic. I followed the pattern of custom app state, and the current behavior is preserved if a `src/server.rs` file is not found. The contract of the custom server function is:
```rust
async fn main(server_address: String, router: Router) -> Result<(), std::io::Error> {
    // custom logic here
}
```

I went back and forth on whether it was better to pass in a `String` or `TcpListener` here, but ultimately did it this way because in the past I've run across libraries where there wasn't any way to customize the listener (e.g. to use rustls over tls) and that's been a hinderance. 

Is this on the right track? Any additional tests or documentation I need to add? I did break the mock server, but I wanted to validate the approach before I fixed things downstream.
