### PR TITLE
feat: Add support passing in custom axum extractors

### DIFF
--- a/crates/tuono_lib_macros/Cargo.toml
+++ b/crates/tuono_lib_macros/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.19.4"
 edition = "2024"
 description = "Superfast React fullstack framework"
 homepage = "https://tuono.dev"
-keywords = [ "react", "typescript", "fullstack", "web", "ssr"]
+keywords = ["react", "typescript", "fullstack", "web", "ssr"]
 repository = "https://github.com/tuono-labs/tuono"
 readme = "../../README.md"
 license-file = "../../LICENSE.md"
 categories = ["web-programming"]
 include = [
-		"src/**/*.rs",
-		"Cargo.toml"
+    "src/**/*.rs",
+    "Cargo.toml"
 ]
 
 [lib]
@@ -20,3 +20,6 @@ proc-macro = true
 [dependencies]
 syn = { version = "2.0.0", features = ["full"] }
 quote = "1.0"
+
+[dev-dependencies]
+tuono_lib = { path = "../tuono_lib" }

--- a/crates/tuono_lib_macros/src/handler.rs
+++ b/crates/tuono_lib_macros/src/handler.rs
@@ -1,44 +1,108 @@
 use crate::utils::{
     crate_application_state_extractor, create_struct_fn_arg, import_main_application_state,
-    params_argument, request_argument,
+    params_argument, parse_parethesized_terminated, request_argument,
 };
 
 use proc_macro::TokenStream;
 use quote::quote;
+use std::collections::HashSet;
+use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
-use syn::{FnArg, ItemFn, Pat, parse_macro_input};
+use syn::{FnArg, Ident, ItemFn, Pat, parse_macro_input};
 
-pub fn handler_core(_args: TokenStream, item: TokenStream) -> TokenStream {
+/// Attributes for the handler proc macro
+#[derive(Default)]
+pub struct HandlerAttr {
+    /// Which arguments should be passed to both axum routes and handler funciton, but
+    /// excluded from state destructuring
+    axum_arguments: HashSet<String>,
+}
+
+impl Parse for HandlerAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        const EXPECTED_ATTRIBUTE_MESSAGE: &str =
+            "unexpected identifier, expected any of: axum_arguments";
+        let mut attr = HandlerAttr::default();
+
+        while !input.is_empty() {
+            let ident = input.parse::<Ident>().map_err(|error| {
+                syn::Error::new(
+                    error.span(),
+                    format!("{EXPECTED_ATTRIBUTE_MESSAGE}, {error}"),
+                )
+            })?;
+            let attribute_name = &*ident.to_string();
+
+            match attribute_name {
+                "axum_arguments" => {
+                    attr.axum_arguments = parse_parethesized_terminated::<Ident, Comma>(input)?
+                        .into_iter()
+                        .map(|ident| ident.to_string())
+                        .collect()
+                }
+                _ => {
+                    return Err(syn::Error::new(ident.span(), EXPECTED_ATTRIBUTE_MESSAGE));
+                }
+            }
+        }
+        Ok(attr)
+    }
+}
+
+pub fn handler_core(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let handler_attribute = syn::parse_macro_input!(attr as HandlerAttr);
     let item = parse_macro_input!(item as ItemFn);
 
     let fn_name = &item.sig.ident;
 
+    let mut state_argument_names: Punctuated<Pat, Comma> = Punctuated::new();
     let mut argument_names: Punctuated<Pat, Comma> = Punctuated::new();
     let mut axum_arguments: Punctuated<FnArg, Comma> = Punctuated::new();
 
+    let mut state_included = false;
+    // The request argument
+    axum_arguments.push(params_argument());
     // Fn Arguments minus the first which always is the request
-    for (i, arg) in item.sig.inputs.iter().enumerate() {
-        if i == 0 {
-            axum_arguments.insert(i, params_argument());
-            continue;
-        }
-
-        if i == 1 {
-            axum_arguments.insert(1, create_struct_fn_arg())
-        }
-
+    for arg in item.sig.inputs.iter().skip(1) {
         if let FnArg::Typed(pat_type) = arg {
-            let index = i - 1;
             let argument_name = *pat_type.pat.clone();
-            argument_names.insert(index, argument_name.clone());
+            match &argument_name {
+                Pat::Ident(ident) => {
+                    if handler_attribute
+                        .axum_arguments
+                        .contains(&ident.ident.to_string())
+                    {
+                        axum_arguments.push(arg.to_owned());
+                        argument_names.push(argument_name.clone());
+                    } else {
+                        // State extractor needs to be included if there are state arguments
+                        if !state_included {
+                            axum_arguments.push(create_struct_fn_arg());
+                            state_included = true;
+                        }
+                        argument_names.push(argument_name.clone());
+                        state_argument_names.push(argument_name.clone());
+                    }
+                }
+                _ => {
+                    // State extractor needs to be included if there are state arguments
+                    if !state_included {
+                        axum_arguments.push(create_struct_fn_arg());
+                        state_included = true;
+                    }
+                    argument_names.push(argument_name.clone());
+                    state_argument_names.push(argument_name.clone());
+                }
+            }
         }
     }
 
     axum_arguments.insert(axum_arguments.len(), request_argument());
 
-    let application_state_extractor = crate_application_state_extractor(argument_names.clone());
-    let application_state_import = import_main_application_state(argument_names.clone());
+    let application_state_extractor =
+        crate_application_state_extractor(state_argument_names.clone());
+    let application_state_import = import_main_application_state(state_argument_names.clone());
 
     quote! {
         #application_state_import

--- a/crates/tuono_lib_macros/src/lib.rs
+++ b/crates/tuono_lib_macros/src/lib.rs
@@ -10,6 +10,15 @@ mod api;
 mod handler;
 mod utils;
 
+/// Automatically generate tuono_internal_route and tuono_internal_api functions for a handler
+///
+/// Axum arguments are passed as parentheses enclosed, comma-separated list of idents
+/// ```text
+/// #[tuono_lib::handler(axum_arguments(foo))]
+/// async fn get_foo(req: Request, bar: String, foo: String) -> Response {
+///     Response::Props(Props::new_with_status(vec![("foo", foo), ("bar", bar)], StatusCode::OK))
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn handler(args: TokenStream, item: TokenStream) -> TokenStream {
     handler::handler_core(args, item)

--- a/crates/tuono_lib_macros/src/utils.rs
+++ b/crates/tuono_lib_macros/src/utils.rs
@@ -1,4 +1,5 @@
 use quote::quote;
+use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{FnArg, Pat, Stmt, parse_quote, parse2};
@@ -44,4 +45,12 @@ pub fn request_argument() -> FnArg {
             request: tuono_lib::axum::extract::Request
     })
     .unwrap()
+}
+
+pub fn parse_parethesized_terminated<T: Parse, S: Parse>(
+    input: ParseStream,
+) -> syn::Result<Punctuated<T, S>> {
+    let group;
+    syn::parenthesized!(group in input);
+    Punctuated::parse_terminated(&group)
 }

--- a/crates/tuono_lib_macros/tests/handler.rs
+++ b/crates/tuono_lib_macros/tests/handler.rs
@@ -1,0 +1,66 @@
+use tuono_lib::axum::http::StatusCode;
+use tuono_lib::cookie::{Cookie, CookieJar};
+use tuono_lib::{Props, Request, Response};
+
+pub mod tuono_main_state {
+    pub struct ApplicationState {
+        pub bar: String,
+    }
+}
+
+#[test]
+fn handler_with_axum_arguments_and_state() {
+    // If this compiles, it's a success
+    #[allow(dead_code)]
+    #[tuono_lib_macros::handler(axum_arguments(cookie_jar))]
+    async fn get_foo(_req: Request, bar: String, cookie_jar: CookieJar) -> Response {
+        let cookie = cookie_jar
+            .get("baz")
+            .cloned()
+            .unwrap_or(Cookie::new("baz", "qux"));
+        Response::Props(Props::new_with_status(
+            vec![
+                ("foo".to_string(), bar),
+                ("baz".to_string(), cookie.to_string()),
+            ],
+            StatusCode::OK,
+        ))
+    }
+}
+
+#[test]
+fn handler_with_axum_arguments_no_state() {
+    // If this compiles, it's a success
+    #[allow(dead_code)]
+    #[tuono_lib_macros::handler(axum_arguments(cookie_jar))]
+    async fn get_foo(_req: Request, cookie_jar: CookieJar) -> Response {
+        let cookie = cookie_jar
+            .get("baz")
+            .cloned()
+            .unwrap_or(Cookie::new("baz", "qux"));
+        Response::Props(Props::new_with_status(
+            vec![("baz".to_string(), cookie.to_string())],
+            StatusCode::OK,
+        ))
+    }
+}
+
+#[test]
+fn handler_with_axum_arguments_reverse_order() {
+    // If this compiles, it's a success
+    #[allow(dead_code)]
+    #[tuono_lib_macros::handler(axum_arguments(cookie_jar))]
+    async fn get_foo(_req: Request, cookie_jar: CookieJar, bar: String) -> Response {
+        let cookie = cookie_jar
+            .get("baz")
+            .cloned()
+            .unwrap_or(Cookie::new("baz", "qux"));
+        Response::Props(Props::new_with_status(
+            vec![
+                ("foo".to_string(), bar),
+                ("baz".to_string(), cookie.to_string()),
+            ],
+            StatusCode::OK,
+        ))
+    }
+}


### PR DESCRIPTION
Introduced `axum_arguments` attribute to the `handler` macro for selective inclusion of arguments. Added parsing, validation, and code generation logic to process these attributes.

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Partially addresses #753 

### Overview

Added a new `axum_arguments` parameter to the `handler` macro that allows for passing in custom/other extractors. The arguments that should be treated as extractors are specified as:

```rust
#[tuono_lib::handler(axum_arguments(foo, bar))]
```
