### PR TITLE
Refactor routing to use a dedicated router file

### DIFF
--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -40,6 +40,7 @@ pub struct App {
     pub route_map: HashMap<String, Route>,
     pub base_path: PathBuf,
     pub has_app_state: bool,
+    pub has_main: bool,
     pub config: Option<Config>,
 }
 
@@ -51,6 +52,14 @@ fn has_app_state(base_path: PathBuf) -> std::io::Result<bool> {
     Ok(contents.contains("pub fn main"))
 }
 
+fn has_main(base_path: PathBuf) -> std::io::Result<bool> {
+    let file = File::open(base_path.join("src/main.rs"))?;
+    let mut buf_reader = BufReader::new(file);
+    let mut contents = String::new();
+    buf_reader.read_to_string(&mut contents)?;
+    Ok(contents.contains("async fn main"))
+}
+
 impl App {
     pub fn new() -> Self {
         let base_path = std::env::current_dir().expect("Failed to read current_dir");
@@ -58,7 +67,8 @@ impl App {
         let mut app = App {
             route_map: HashMap::new(),
             base_path: base_path.clone(),
-            has_app_state: has_app_state(base_path).unwrap_or(false),
+            has_app_state: has_app_state(base_path.to_owned()).unwrap_or(false),
+            has_main: has_main(base_path).unwrap_or(false),
             config: None,
         };
 
@@ -253,7 +263,6 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]

--- a/crates/tuono/templates/router.rs
+++ b/crates/tuono/templates/router.rs
@@ -1,0 +1,24 @@
+// File automatically generated
+// Do not manually change it
+
+use tuono_lib::{axum::Router, tuono_internal_init_v8_platform, Mode, Server};
+
+//AXUM_GET_ROUTE_HANDLER//
+
+const MODE: Mode = //MODE//;
+
+//MODULE_IMPORTS//
+
+//APP_STATE_IMPORT//
+
+pub async fn init_server() -> Server {
+    tuono_internal_init_v8_platform();
+    //APP_STATE_DECLARATION//
+    let router = Router::new()
+    //ROUTE_BUILDER//
+    //APP_STATE_USAGE//;
+    if MODE == Mode::Prod {
+        println!("\n  ⚡ Tuono v//VERSION//");
+    }
+    Server::init(router, MODE).await
+}

--- a/crates/tuono/templates/server.rs
+++ b/crates/tuono/templates/server.rs
@@ -1,29 +1,12 @@
 // File automatically generated
 // Do not manually change it
 
-use tuono_lib::{tokio, Mode, Server, axum::Router, tuono_internal_init_v8_platform};
-// AXUM_GET_ROUTE_HANDLER
+mod router;
 
-const MODE: Mode = /*MODE*/;
-
-// MODULE_IMPORTS
-
-//MAIN_FILE_IMPORT//
+use tuono_lib::{Mode, Server, axum::Router, tokio, tuono_internal_init_v8_platform};
 
 #[tokio::main]
 async fn main() {
-    tuono_internal_init_v8_platform();
-    
-    if MODE == Mode::Prod {
-        println!("\n  ⚡ Tuono v/*VERSION*/");
-    }
-
-    //MAIN_FILE_DEFINITION//
-
-    let router = Router::new()
-        // ROUTE_BUILDER
-        //MAIN_FILE_USAGE//;
-
-    Server::init(router, MODE).await.start().await
+    let server = router::init_server().await;
+    server.start().await
 }
-

--- a/crates/tuono/tests/cli_build.rs
+++ b/crates/tuono/tests/cli_build.rs
@@ -33,10 +33,10 @@ fn it_successfully_create_the_index_route() {
         .assert()
         .success();
 
-    let temp_main_rs_path = temp_tuono_project.path().join(".tuono/main.rs");
+    let temp_router_rs_path = temp_tuono_project.path().join(".tuono/router.rs");
 
-    let temp_main_rs_content =
-        fs::read_to_string(&temp_main_rs_path).expect("Failed to read '.tuono/main.rs' content.");
+    let temp_main_rs_content = fs::read_to_string(&temp_router_rs_path)
+        .expect("Failed to read '.tuono/router.rs' content.");
 
     assert!(temp_main_rs_content.contains(r#"#[path="../src/routes/index.rs"]"#));
     assert!(temp_main_rs_content.contains("mod index;"));
@@ -59,15 +59,15 @@ fn it_successfully_create_an_api_route() {
         .assert()
         .success();
 
-    let temp_main_rs_path = temp_tuono_project.path().join(".tuono/main.rs");
+    let temp_router_rs_path = temp_tuono_project.path().join(".tuono/router.rs");
 
-    let temp_main_rs_content =
-        fs::read_to_string(&temp_main_rs_path).expect("Failed to read '.tuono/main.rs' content.");
+    let temp_router_rs_content = fs::read_to_string(&temp_router_rs_path)
+        .expect("Failed to read '.tuono/router.rs' content.");
 
-    assert!(temp_main_rs_content.contains(r#"#[path="../src/routes/api/health_check.rs"]"#));
-    assert!(temp_main_rs_content.contains("mod api_health_check;"));
+    assert!(temp_router_rs_content.contains(r#"#[path="../src/routes/api/health_check.rs"]"#));
+    assert!(temp_router_rs_content.contains("mod api_health_check;"));
 
-    assert!(temp_main_rs_content.contains(
+    assert!(temp_router_rs_content.contains(
         r#".route("/api/health_check", post(api_health_check::post_tuono_internal_api))"#
     ));
 }
@@ -89,10 +89,10 @@ fn it_successfully_create_multiple_api_for_the_same_file() {
         .assert()
         .success();
 
-    let temp_main_rs_path = temp_tuono_project.path().join(".tuono/main.rs");
+    let temp_router_rs_path = temp_tuono_project.path().join(".tuono/router.rs");
 
-    let temp_main_rs_content =
-        fs::read_to_string(&temp_main_rs_path).expect("Failed to read '.tuono/main.rs' content.");
+    let temp_main_rs_content = fs::read_to_string(&temp_router_rs_path)
+        .expect("Failed to read '.tuono/router.rs' content.");
 
     assert!(temp_main_rs_content.contains(r#"#[path="../src/routes/api/health_check.rs"]"#));
     assert!(temp_main_rs_content.contains("mod api_health_check;"));
@@ -123,10 +123,10 @@ fn it_successfully_create_catch_all_routes() {
         .assert()
         .success();
 
-    let temp_main_rs_path = temp_tuono_project.path().join(".tuono/main.rs");
+    let temp_router_rs_path = temp_tuono_project.path().join(".tuono/router.rs");
 
-    let temp_main_rs_content =
-        fs::read_to_string(&temp_main_rs_path).expect("Failed to read '.tuono/main.rs' content.");
+    let temp_main_rs_content = fs::read_to_string(&temp_router_rs_path)
+        .expect("Failed to read '.tuono/router.rs' content.");
 
     assert!(temp_main_rs_content.contains(r#"#[path="../src/routes/api/[...all_apis].rs"]"#));
     assert!(temp_main_rs_content.contains("mod api_dyn_catch_all_all_apis;"));

--- a/crates/tuono_lib_macros/src/utils.rs
+++ b/crates/tuono_lib_macros/src/utils.rs
@@ -13,7 +13,7 @@ pub fn create_struct_fn_arg() -> FnArg {
 pub fn import_main_application_state(argument_names: Punctuated<Pat, Comma>) -> Option<Stmt> {
     if !argument_names.is_empty() {
         let local: Stmt = parse_quote!(
-            use crate::tuono_main_state::ApplicationState;
+            use crate::router::tuono_main_state::ApplicationState;
         );
         return Some(local);
     }


### PR DESCRIPTION
Move functionality from `.tuono/main.rs` to `.tuono/router.rs` to allow users to override `main.rs`. Updated all related references, logic, and tests to use the new router file for route handling. Introduced a modular approach to improve maintainability and clarity in routing logic.

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes #762 

### Overview

Allow the user to override `main.rs` by moving core functionality into a new `.tuono/router.rs` file. If no user supplied `main.rs` file is found, one is created at `.tuono/main.rs` with the content

```
// File automatically generated
// Do not manually change it

mod router;

use tuono_lib::{Mode, Server, axum::Router, tokio, tuono_internal_init_v8_platform};

#[tokio::main]
async fn main() {
    let server = router::init_server().await;
    server.start().await
}
```

and the user can override this by creating a `src/main.rs` with the contents
```
#[path = "../.tuono/router.rs"]
mod router;

use tuono_lib::tokio;

#[tokio::main]
async fn main() {
    let server = router::init_server().await;
    // custom logic here
}
```

and updating `Cargo.toml` to use the overridden main file
```
[[bin]]
name = "tuono"
path = "src/main.rs"
```