### PR TITLE
fix(crates/tuono): Fix HTTP method handling for mixed-case input

### DIFF
--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -253,7 +253,6 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -102,7 +102,7 @@ fn read_http_methods_from_file(path: &String) -> Vec<Method> {
                 // Extract just the element surrounded by the phrantesist.
                 .replace("tuono_lib::api(", "")
                 .replace(")]", "");
-            Method::from_str(http_method.as_str()).unwrap_or(Method::GET)
+            Method::from_str(http_method.to_uppercase().as_str()).unwrap_or(Method::GET)
         })
         .collect::<Vec<Method>>()
 }
@@ -283,7 +283,6 @@ impl Route {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]


### PR DESCRIPTION
Ensure HTTP methods are processed in uppercase to prevent mismatches. Added tests to validate the handling of routes with mixed-case HTTP method annotations and confirmed correct generation of imports.


### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

None

### Overview

Discovered kind of a fun bug testing my other changes. You'd think a  `HashSet<Method>` would only store unique http methods, but for reasons I don't really understand - that isn't honored when you use `Method::from_str()`. The effect of this in tuono is that if you had macros defined for api with mixed case, e.g. `#[handler(GET)]` and `#[handler(get)]` it would work fine, except you get duplicate imports in the generated main. This case would hit anyone who used the lowercase notation in a bootstrapped project because the templated healthcheck api uses uppercase.
