### PR TITLE
fix: Remove false negative CriticalCSS messages; addresses issue # 772

### DIFF
--- a/packages/tuono-react-vite-plugin/src/styles.ts
+++ b/packages/tuono-react-vite-plugin/src/styles.ts
@@ -3,6 +3,7 @@
  *
  * source: https://github.com/remix-run/remix/blob/main/packages/remix-dev/vite/styles.ts
  */
+import fs from 'fs'
 import path from 'path'
 
 import type { ModuleNode, ViteDevServer } from 'vite'
@@ -165,8 +166,12 @@ export const getStylesForComponentId = async (
     routesFolder,
     findFileFromComponentId(componentId || ''),
   )
+  
+  let fileUrl = path.join(process.cwd(), relativeFilePath)
 
-  const fileUrl = path.join(process.cwd(), relativeFilePath)
+  if (fs.existsSync(`${fileUrl}.mdx`)) {
+    fileUrl = path.format({ name: fileUrl, ext: '.mdx' })
+  }
 
   return await getStylesForModule(viteDevServer, fileUrl, cssModulesManifest)
 }

--- a/packages/tuono-react-vite-plugin/src/styles.ts
+++ b/packages/tuono-react-vite-plugin/src/styles.ts
@@ -169,6 +169,8 @@ export const getStylesForComponentId = async (
   
   let fileUrl = path.join(process.cwd(), relativeFilePath)
 
+  // For .mdx files we have to make sure the extension is added to prevent
+  // false negative input in the terminal about the index.mdx file missing. 
   if (fs.existsSync(`${fileUrl}.mdx`)) {
     fileUrl = path.format({ name: fileUrl, ext: '.mdx' })
   }

--- a/packages/tuono-react-vite-plugin/src/styles.ts
+++ b/packages/tuono-react-vite-plugin/src/styles.ts
@@ -166,11 +166,11 @@ export const getStylesForComponentId = async (
     routesFolder,
     findFileFromComponentId(componentId || ''),
   )
-  
+
   let fileUrl = path.join(process.cwd(), relativeFilePath)
 
   // For .mdx files we have to make sure the extension is added to prevent
-  // false negative input in the terminal about the index.mdx file missing. 
+  // false negative input in the terminal about the index.mdx file missing.
   if (fs.existsSync(`${fileUrl}.mdx`)) {
     fileUrl = path.format({ name: fileUrl, ext: '.mdx' })
   }


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes: https://github.com/tuono-labs/tuono/issues/772

### Overview

Fixes an edge case for mdx files where the extension is needed to prevent CriticalCSS errors.
