### PR TITLE
feat(middleware) Added support for axum middlewares #760

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+edition = "2024"
+
 [workspace]
 resolver = "2"
 members = [

--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive", "cargo"] }
-syn = { version = "2.0.100", features = ["full"] }
+syn = { version = "2.0.100", features = ["full","extra-traits"] }
 tracing = "0.1.41"
 tracing-subscriber = {version = "0.3.19", features = ["env-filter"]}
 miette = "7.2.0"
@@ -41,6 +41,7 @@ tuono_internal = {path = "../tuono_internal", version = "0.19.7"}
 spinners = "4.1.1"
 console = "0.16.0"
 convert_case = "0.8.0"
+quote = "1.0.45"
 
 [dev-dependencies]
 wiremock = "0.6.2"

--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -1,6 +1,6 @@
 use crate::mode::Mode;
 use crate::route::Route;
-use crate::route_directory_info::RouteDirectoryInfo;
+use crate::route_directory_info::{DebugItemFn, MiddlewareData, RouteDirectoryInfo};
 use glob::{GlobError, glob};
 use http::Method;
 use std::collections::hash_set::HashSet;
@@ -14,6 +14,8 @@ use std::path::PathBuf;
 use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
+use std::sync::Arc;
+use syn::Item;
 use tracing::error;
 use tuono_internal::config::Config;
 
@@ -46,11 +48,12 @@ pub struct App {
 }
 
 fn has_app_state(base_path: PathBuf) -> std::io::Result<bool> {
-    let file = File::open(base_path.join("src/app.rs"))?;
+    let full_path = base_path.join("src/app.rs");
+    let file = File::open(full_path)?;
     let mut buf_reader = BufReader::new(file);
     let mut contents = String::new();
     buf_reader.read_to_string(&mut contents)?;
-    Ok(contents.contains("pub fn main"))
+    Ok(contents.contains("pub fn main") || contents.contains("pub async fn main"))
 }
 
 impl App {

--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -1,5 +1,6 @@
 use crate::mode::Mode;
 use crate::route::Route;
+use crate::route_directory_info::RouteDirectoryInfo;
 use glob::{GlobError, glob};
 use http::Method;
 use std::collections::hash_set::HashSet;
@@ -16,11 +17,11 @@ use std::process::Stdio;
 use tracing::error;
 use tuono_internal::config::Config;
 
-const IGNORE_EXTENSIONS: [&str; 3] = ["css", "scss", "sass"];
-const IGNORE_FILES: [&str; 1] = ["__layout"];
+pub const IGNORE_EXTENSIONS: [&str; 3] = ["css", "scss", "sass"];
+pub const IGNORE_FILES: [&str; 2] = ["__layout", "middlewares"];
 
 #[cfg(target_os = "windows")]
-const ROUTES_FOLDER_PATH: &str = "\\src\\routes";
+pub const ROUTES_FOLDER_PATH: &str = "\\src\\routes";
 #[cfg(target_os = "windows")]
 const BUILD_JS_SCRIPT: &str = ".\\node_modules\\.bin\\tuono-build-prod.cmd";
 
@@ -28,7 +29,7 @@ const BUILD_JS_SCRIPT: &str = ".\\node_modules\\.bin\\tuono-build-prod.cmd";
 const BUILD_TUONO_CONFIG: &str = ".\\node_modules\\.bin\\tuono-build-config.cmd";
 
 #[cfg(not(target_os = "windows"))]
-const ROUTES_FOLDER_PATH: &str = "/src/routes";
+pub const ROUTES_FOLDER_PATH: &str = "/src/routes";
 #[cfg(not(target_os = "windows"))]
 const BUILD_JS_SCRIPT: &str = "./node_modules/.bin/tuono-build-prod";
 
@@ -41,6 +42,7 @@ pub struct App {
     pub base_path: PathBuf,
     pub has_app_state: bool,
     pub config: Option<Config>,
+    pub route_directory_info: RouteDirectoryInfo,
 }
 
 fn has_app_state(base_path: PathBuf) -> std::io::Result<bool> {
@@ -54,12 +56,15 @@ fn has_app_state(base_path: PathBuf) -> std::io::Result<bool> {
 impl App {
     pub fn new() -> Self {
         let base_path = std::env::current_dir().expect("Failed to read current_dir");
-
+        let base_path_str = base_path.to_string_lossy();
+        let routes_path_str = format!("{base_path_str}{ROUTES_FOLDER_PATH}");
+        let routes_path = Path::new(&routes_path_str);
         let mut app = App {
             route_map: HashMap::new(),
             base_path: base_path.clone(),
             has_app_state: has_app_state(base_path).unwrap_or(false),
             config: None,
+            route_directory_info: RouteDirectoryInfo::new(routes_path).unwrap_or_default(),
         };
 
         app.collect_routes();
@@ -270,6 +275,7 @@ mod tests {
             "\\home\\user\\Documents\\tuono\\src\\routes\\about.rs",
             "\\home\\user\\Documents\\tuono\\src\\routes\\index.rs",
             "\\home\\user\\Documents\\tuono\\src\\routes\\posts\\index.rs",
+            "\\home\\user\\Documents\\tuono\\src\\routes\\posts\\middlewares.rs",
             "\\home\\user\\Documents\\tuono\\src\\routes\\posts\\[post].rs",
             "\\home\\user\\Documents\\tuono\\src\\routes\\posts\\handle-this.rs",
             "\\home\\user\\Documents\\tuono\\src\\routes\\posts\\handle-this\\[post].rs",
@@ -283,6 +289,7 @@ mod tests {
             "/home/user/Documents/tuono/src/routes/index.rs",
             "/home/user/Documents/tuono/src/routes/posts/index.rs",
             "/home/user/Documents/tuono/src/routes/posts/[post].rs",
+            "/home/user/Documents/tuono/src/routes/posts/middlewares.rs",
             "/home/user/Documents/tuono/src/routes/posts/handle-this.rs",
             "/home/user/Documents/tuono/src/routes/posts/handle-this/[post].rs",
             "/home/user/Documents/tuono/src/routes/posts/UPPERCASE.rs",

--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -1,6 +1,6 @@
 use crate::mode::Mode;
 use crate::route::Route;
-use crate::route_directory_info::{DebugItemFn, MiddlewareData, RouteDirectoryInfo};
+use crate::route_directory_info::RouteDirectoryInfo;
 use glob::{GlobError, glob};
 use http::Method;
 use std::collections::hash_set::HashSet;
@@ -14,8 +14,6 @@ use std::path::PathBuf;
 use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
-use std::sync::Arc;
-use syn::Item;
 use tracing::error;
 use tuono_internal::config::Config;
 

--- a/crates/tuono/src/commands/dev.rs
+++ b/crates/tuono/src/commands/dev.rs
@@ -88,11 +88,10 @@ pub async fn watch(source_builder: SourceBuilder) -> Result<()> {
 
     // Server address log for production
     // is done on the server process.
-    if let Ok(builder) = source_builder.read() {
-        if let Ok(pm) = process_manager.lock() {
+    if let Ok(builder) = source_builder.read()
+        && let Ok(pm) = process_manager.lock() {
             pm.log_server_address(builder.app.config.clone().unwrap_or_default());
         }
-    }
 
     let wx = Watchexec::new(move |mut action| {
         let process_manager = process_manager.clone();
@@ -144,8 +143,8 @@ pub async fn watch(source_builder: SourceBuilder) -> Result<()> {
             }
         }
 
-        if !paths_to_refresh_types.is_empty() {
-            if let Ok(mut builder) = source_builder.write() {
+        if !paths_to_refresh_types.is_empty()
+            && let Ok(mut builder) = source_builder.write() {
                 for path in paths_to_refresh_types {
                     // There is no need to check here if the `Type` trait is
                     // derived since it will be checked later by the TypeJar struct.
@@ -155,10 +154,9 @@ pub async fn watch(source_builder: SourceBuilder) -> Result<()> {
                     error!("Failed to generate typescript file");
                 };
             }
-        }
 
-        if !removed_files_from_types.is_empty() {
-            if let Ok(mut builder) = source_builder.write() {
+        if !removed_files_from_types.is_empty()
+            && let Ok(mut builder) = source_builder.write() {
                 for path in removed_files_from_types {
                     builder.remove_typescript_file(path);
                 }
@@ -166,26 +164,23 @@ pub async fn watch(source_builder: SourceBuilder) -> Result<()> {
                     error!("Failed to generate typescript file");
                 };
             }
-        }
 
         if should_reload_rust_server || should_refresh_axum_source {
             tuono_println!("Reloading...");
-            if should_refresh_axum_source {
-                if let Ok(mut builder) = source_builder.write() {
+            if should_refresh_axum_source
+                && let Ok(mut builder) = source_builder.write() {
                     builder.app.collect_routes();
                     _ = builder.refresh_axum_source();
                 }
-            }
             if let Ok(mut pm) = process_manager.lock() {
                 pm.restart_process(ProcessId::RunRustDevServer);
             }
         }
 
-        if should_reload_ssr_bundle {
-            if let Ok(mut pm) = process_manager.lock() {
+        if should_reload_ssr_bundle
+            && let Ok(mut pm) = process_manager.lock() {
                 pm.restart_process(ProcessId::BuildReactSSRSrc);
             }
-        }
 
         action
     })?;

--- a/crates/tuono/src/lib.rs
+++ b/crates/tuono/src/lib.rs
@@ -2,13 +2,13 @@
 //! Tuono is a full-stack web framework for building React applications using Rust as the backend with a strong focus on usability and performance.
 //!
 //! You can find the full documentation at [tuono.dev](https://tuono.dev/)
-
 mod app;
 pub mod cli;
 mod commands;
 mod mode;
 mod process_manager;
 mod route;
+mod route_directory_info;
 mod source_builder;
 mod symbols;
 mod typescript;

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -181,13 +181,12 @@ impl Route {
             }
         };
 
-        if !parent_dir.is_dir() {
-            if let Err(err) = create_all(parent_dir, false) {
+        if !parent_dir.is_dir()
+            && let Err(err) = create_all(parent_dir, false) {
                 return Err(format!(
                     "Failed to create the parent directory {parent_dir:?}\nError: {err}"
                 ));
             }
-        }
 
         trace!("Saving the HTML file: {:?}", file_path);
 
@@ -215,13 +214,12 @@ impl Route {
                 }
             };
 
-            if !data_parent_dir.is_dir() {
-                if let Err(err) = create_all(data_parent_dir, false) {
+            if !data_parent_dir.is_dir()
+                && let Err(err) = create_all(data_parent_dir, false) {
                     return Err(format!(
                         "Failed to create the parent directory {data_parent_dir:?}\n Error: {err}"
                     ));
                 }
-            }
 
             let base = Url::parse("http://localhost:3000/__tuono/data").unwrap();
 

--- a/crates/tuono/src/route_directory_info.rs
+++ b/crates/tuono/src/route_directory_info.rs
@@ -1,10 +1,15 @@
 use crate::app::{IGNORE_EXTENSIONS, IGNORE_FILES, ROUTES_FOLDER_PATH};
 use crate::route::Route;
+use quote::quote;
 use std::collections::{HashMap, hash_map::Entry};
+use std::fmt::Debug;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use syn::{Attribute, Item};
+use std::sync::{Arc, Mutex};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{Attribute, Expr, FnArg, Ident, Item, ItemFn, parse_quote};
 
 pub const MIDDLEWARE_FILENAME: &str = "middlewares";
 
@@ -13,7 +18,7 @@ pub struct RouteDirectoryInfo {
     pub path: String,
     pub directories: Vec<RouteDirectoryInfo>,
     pub routes: HashMap<String, Route>,
-    pub middlewares: Vec<String>,
+    pub middlewares: Arc<Mutex<Vec<DebugItemFn>>>,
 }
 
 impl RouteDirectoryInfo {
@@ -38,10 +43,11 @@ impl RouteDirectoryInfo {
                         // check if middlewares file
                         if name_str == format!("{MIDDLEWARE_FILENAME}.rs") {
                             // scan middleware file for middleware layer functions
-                            let middleware_data: Option<MiddlewareData> = MiddlewareData::new(
+                            let middleware_data: MiddlewareData = MiddlewareData::new(
                                 &entry_path.to_str().expect("Invalid filepath").to_string(),
-                            );
-                            middlewares = middleware_data.unwrap_or_default().middlewares;
+                            )
+                            .unwrap_or_default();
+                            middlewares = middleware_data.middlewares.lock().unwrap().to_vec(); //.unwrap_or_default();
                         } else {
                             // Generate Routes from file, add to routes
                             if RouteDirectoryInfo::should_collect_route(&entry_path) {
@@ -55,8 +61,8 @@ impl RouteDirectoryInfo {
             let dir_info = RouteDirectoryInfo {
                 path: path.to_string_lossy().to_string(),
                 directories,
-                routes: routes,
-                middlewares,
+                routes,
+                middlewares: Arc::new(Mutex::new(middlewares)),
             };
 
             Ok(dir_info)
@@ -66,13 +72,13 @@ impl RouteDirectoryInfo {
                 path: path.to_string_lossy().to_string(),
                 directories: Vec::new(),
                 routes: HashMap::new(),
-                middlewares: Vec::new(),
+                middlewares: Arc::new(Mutex::new(Vec::new())),
             })
         }
     }
 
     pub fn has_middlewares(&self) -> bool {
-        !self.middlewares.is_empty()
+        !self.middlewares.lock().unwrap().is_empty()
     }
 
     pub fn get_middleware_module_import(&self) -> String {
@@ -115,7 +121,7 @@ impl RouteDirectoryInfo {
     }
 
     fn collect_route(entry: PathBuf, routes: HashMap<String, Route>) -> HashMap<String, Route> {
-        let mut ret_routes = routes.clone();
+        let mut ret_routes: HashMap<String, Route> = routes.clone();
         let base_path = RouteDirectoryInfo::get_base_path();
         let base_path_str = base_path.to_string_lossy();
         let path = entry
@@ -147,9 +153,43 @@ impl RouteDirectoryInfo {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct DebugItemFn {
+    pub fn_call_str: String,
+}
+
+impl DebugItemFn {
+    pub fn get_fn_call_to_str(item: &ItemFn) -> String {
+        let mut arguments: Punctuated<FnArg, Comma> = Punctuated::new();
+        let mut passed_arguments: Punctuated<Expr, Comma> = Punctuated::new();
+        for (i, arg) in item.sig.inputs.iter().enumerate() {
+            if let FnArg::Typed(pat_type) = arg {
+                let arg_name = Ident::new(&format!("arg_{}", i), item.sig.ident.span());
+                let arg_type = &pat_type.ty;
+                let argument: FnArg = parse_quote!(#arg_name: #arg_type);
+                arguments.push(argument);
+                passed_arguments.push(parse_quote!(#arg_name));
+            }
+        }
+
+        let sig_ident_str = &item.sig.ident.to_string();
+        let with_args_str = quote!(#passed_arguments).to_string();
+
+        format!("{sig_ident_str}({with_args_str})")
+    }
+}
+
+impl From<ItemFn> for DebugItemFn {
+    fn from(item: ItemFn) -> Self {
+        return DebugItemFn {
+            fn_call_str: DebugItemFn::get_fn_call_to_str(&item),
+        };
+    }
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct MiddlewareData {
-    pub middlewares: Vec<String>,
+    pub middlewares: Arc<Mutex<Vec<DebugItemFn>>>,
 }
 
 impl MiddlewareData {
@@ -163,7 +203,7 @@ impl MiddlewareData {
     }
 
     // Given an array of syn::Attribute, returns true if the segments are "tuono_lib" and "middleware"
-    fn has_middleware_attr(attrs: &[Attribute]) -> bool {
+    pub fn has_middleware_attr(attrs: &[Attribute]) -> bool {
         attrs.iter().any(|attr| {
             let path = attr.path();
 
@@ -174,7 +214,7 @@ impl MiddlewareData {
     }
 
     // Reads a middlewares.rs file and returns a Vector of Strings representing functions that were decorated with the tuono_lib::middleware macro
-    fn read_middleware_methods_from_file(path: &str) -> Vec<String> {
+    pub fn read_middleware_methods_from_file(path: &str) -> Arc<Mutex<Vec<DebugItemFn>>> {
         let file = fs_extra::file::read_to_string(path).expect("Failed to read API file");
         let syntax = syn::parse_file(&file).expect("Unable to parse file");
         let mut result = Vec::new();
@@ -182,11 +222,11 @@ impl MiddlewareData {
         for item in syntax.items {
             if let Item::Fn(func) = item {
                 if MiddlewareData::has_middleware_attr(&func.attrs) {
-                    result.push(func.sig.ident.to_string());
+                    result.push(DebugItemFn::from(func));
                 }
             }
         }
-        return result;
+        return Arc::new(Mutex::new(result));
     }
 }
 
@@ -200,7 +240,9 @@ mod tests {
     #[test]
     fn test_has_middlewares() {
         let dir_info = RouteDirectoryInfo {
-            middlewares: vec!["middleware1".to_string()],
+            middlewares: Arc::new(Mutex::new(vec![DebugItemFn {
+                fn_call_str: "middleware1(app_state:AppState)".to_string(),
+            }])),
             ..Default::default()
         };
         assert!(dir_info.has_middlewares());
@@ -268,7 +310,7 @@ mod tests {
         let dir_info = RouteDirectoryInfo::new(temp_dir.path()).unwrap();
         assert_eq!(dir_info.path, temp_dir.path().to_string_lossy());
         assert!(!dir_info.directories.is_empty());
-        assert!(!dir_info.middlewares.is_empty());
+        assert!(!dir_info.middlewares.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -280,7 +322,13 @@ mod tests {
 
         let middleware_data =
             MiddlewareData::new(&middlewares_file.to_string_lossy().to_string()).unwrap();
-        assert_eq!(middleware_data.middlewares, vec!["test_middleware"]);
+        let middlewares = middleware_data.middlewares.lock().unwrap();
+        assert_eq!(
+            middlewares.as_slice(),
+            [DebugItemFn {
+                fn_call_str: "test_middleware()".to_string(),
+            }]
+        );
     }
 
     #[test]
@@ -305,6 +353,12 @@ mod tests {
 
         let methods =
             MiddlewareData::read_middleware_methods_from_file(&middlewares_file.to_string_lossy());
-        assert_eq!(methods, vec!["test_middleware"]);
+        let middlewares = methods.lock().unwrap();
+        assert_eq!(
+            middlewares.as_slice(),
+            [DebugItemFn {
+                fn_call_str: "test_middleware()".to_string(),
+            }]
+        );
     }
 }

--- a/crates/tuono/src/route_directory_info.rs
+++ b/crates/tuono/src/route_directory_info.rs
@@ -75,7 +75,6 @@ impl RouteDirectoryInfo {
         !self.middlewares.is_empty()
     }
 
-
     pub fn get_middleware_module_import(&self) -> String {
         let base_path = RouteDirectoryInfo::get_base_path();
         let base_path_str = base_path.to_string_lossy();
@@ -279,7 +278,8 @@ mod tests {
         let mut file = File::create(&middlewares_file).unwrap();
         writeln!(file, "#[tuono_lib::middleware]\nfn test_middleware() {{}}").unwrap();
 
-        let middleware_data = MiddlewareData::new(&middlewares_file.to_string_lossy().to_string()).unwrap();
+        let middleware_data =
+            MiddlewareData::new(&middlewares_file.to_string_lossy().to_string()).unwrap();
         assert_eq!(middleware_data.middlewares, vec!["test_middleware"]);
     }
 
@@ -297,9 +297,14 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let middlewares_file = temp_dir.path().join("middlewares.rs");
         let mut file = File::create(&middlewares_file).unwrap();
-        writeln!(file, "#[tuono_lib::middleware]\nfn test_middleware() {{}}\nfn other_fn() {{}}").unwrap();
+        writeln!(
+            file,
+            "#[tuono_lib::middleware]\nfn test_middleware() {{}}\nfn other_fn() {{}}"
+        )
+        .unwrap();
 
-        let methods = MiddlewareData::read_middleware_methods_from_file(&middlewares_file.to_string_lossy());
+        let methods =
+            MiddlewareData::read_middleware_methods_from_file(&middlewares_file.to_string_lossy());
         assert_eq!(methods, vec!["test_middleware"]);
     }
 }

--- a/crates/tuono/src/route_directory_info.rs
+++ b/crates/tuono/src/route_directory_info.rs
@@ -37,22 +37,22 @@ impl RouteDirectoryInfo {
                     let sub_dir_info = RouteDirectoryInfo::new(&entry_path)?;
                     directories.push(sub_dir_info);
                 // handle files
-                } else if entry_path.is_file() {
-                    if let Some(name) = entry_path.file_name() {
-                        let name_str = name.to_string_lossy().to_string();
-                        // check if middlewares file
-                        if name_str == format!("{MIDDLEWARE_FILENAME}.rs") {
-                            // scan middleware file for middleware layer functions
-                            let middleware_data: MiddlewareData = MiddlewareData::new(
-                                &entry_path.to_str().expect("Invalid filepath").to_string(),
-                            )
-                            .unwrap_or_default();
-                            middlewares = middleware_data.middlewares.lock().unwrap().to_vec(); //.unwrap_or_default();
-                        } else {
-                            // Generate Routes from file, add to routes
-                            if RouteDirectoryInfo::should_collect_route(&entry_path) {
-                                routes = RouteDirectoryInfo::collect_route(entry_path, routes);
-                            }
+                } else if entry_path.is_file()
+                    && let Some(name) = entry_path.file_name()
+                {
+                    let name_str = name.to_string_lossy().to_string();
+                    // check if middlewares file
+                    if name_str == format!("{MIDDLEWARE_FILENAME}.rs") {
+                        // scan middleware file for middleware layer functions
+                        let middleware_data: MiddlewareData = MiddlewareData::new(
+                            &entry_path.to_str().expect("Invalid filepath").to_string(),
+                        )
+                        .unwrap_or_default();
+                        middlewares = middleware_data.middlewares.lock().unwrap().to_vec(); //.unwrap_or_default();
+                    } else {
+                        // Generate Routes from file, add to routes
+                        if RouteDirectoryInfo::should_collect_route(&entry_path) {
+                            routes = RouteDirectoryInfo::collect_route(entry_path, routes);
                         }
                     }
                 }
@@ -95,7 +95,7 @@ impl RouteDirectoryInfo {
             .replace('.', "_dot_")
             .replace('-', "_hyphen_")
             .to_lowercase();
-        if module_import != "" {
+        if !module_import.is_empty() {
             module_import += "_"
         }
 
@@ -106,7 +106,7 @@ impl RouteDirectoryInfo {
         std::env::current_dir().expect("Failed to read current_dir")
     }
 
-    pub fn should_collect_route(entry: &PathBuf) -> bool {
+    pub fn should_collect_route(entry: &Path) -> bool {
         let file_extension = entry.extension().expect("Failed to read file extension");
         let file_name = entry.file_stem().expect("Failed to read file name");
 
@@ -181,9 +181,9 @@ impl DebugItemFn {
 
 impl From<ItemFn> for DebugItemFn {
     fn from(item: ItemFn) -> Self {
-        return DebugItemFn {
+        DebugItemFn {
             fn_call_str: DebugItemFn::get_fn_call_to_str(&item),
-        };
+        }
     }
 }
 
@@ -194,10 +194,10 @@ pub struct MiddlewareData {
 
 impl MiddlewareData {
     pub fn new(path: &String) -> Option<Self> {
-        if !(std::fs::exists(&path).unwrap_or_default()) {
+        if !(std::fs::exists(path).unwrap_or_default()) {
             return None;
         }
-        let middlewares = MiddlewareData::read_middleware_methods_from_file(&path);
+        let middlewares = MiddlewareData::read_middleware_methods_from_file(path);
 
         Some(MiddlewareData { middlewares })
     }
@@ -220,13 +220,13 @@ impl MiddlewareData {
         let mut result = Vec::new();
 
         for item in syntax.items {
-            if let Item::Fn(func) = item {
-                if MiddlewareData::has_middleware_attr(&func.attrs) {
-                    result.push(DebugItemFn::from(func));
-                }
+            if let Item::Fn(func) = item
+                && MiddlewareData::has_middleware_attr(&func.attrs)
+            {
+                result.push(DebugItemFn::from(func));
             }
         }
-        return Arc::new(Mutex::new(result));
+        Arc::new(Mutex::new(result))
     }
 }
 

--- a/crates/tuono/src/route_directory_info.rs
+++ b/crates/tuono/src/route_directory_info.rs
@@ -1,0 +1,305 @@
+use crate::app::{IGNORE_EXTENSIONS, IGNORE_FILES, ROUTES_FOLDER_PATH};
+use crate::route::Route;
+use std::collections::{HashMap, hash_map::Entry};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use syn::{Attribute, Item};
+
+pub const MIDDLEWARE_FILENAME: &str = "middlewares";
+
+#[derive(Clone, Debug, Default)]
+pub struct RouteDirectoryInfo {
+    pub path: String,
+    pub directories: Vec<RouteDirectoryInfo>,
+    pub routes: HashMap<String, Route>,
+    pub middlewares: Vec<String>,
+}
+
+impl RouteDirectoryInfo {
+    pub fn new(path: &Path) -> io::Result<RouteDirectoryInfo> {
+        if path.is_dir() {
+            let mut directories = Vec::new();
+            let mut routes: HashMap<String, Route> = HashMap::new();
+            let mut middlewares = Vec::new();
+
+            for entry in fs::read_dir(path)? {
+                let entry = entry?;
+                let entry_path = entry.path();
+
+                // recursively search directories
+                if entry_path.is_dir() {
+                    let sub_dir_info = RouteDirectoryInfo::new(&entry_path)?;
+                    directories.push(sub_dir_info);
+                // handle files
+                } else if entry_path.is_file() {
+                    if let Some(name) = entry_path.file_name() {
+                        let name_str = name.to_string_lossy().to_string();
+                        // check if middlewares file
+                        if name_str == format!("{MIDDLEWARE_FILENAME}.rs") {
+                            // scan middleware file for middleware layer functions
+                            let middleware_data: Option<MiddlewareData> = MiddlewareData::new(
+                                &entry_path.to_str().expect("Invalid filepath").to_string(),
+                            );
+                            middlewares = middleware_data.unwrap_or_default().middlewares;
+                        } else {
+                            // Generate Routes from file, add to routes
+                            if RouteDirectoryInfo::should_collect_route(&entry_path) {
+                                routes = RouteDirectoryInfo::collect_route(entry_path, routes);
+                            }
+                        }
+                    }
+                }
+            }
+
+            let dir_info = RouteDirectoryInfo {
+                path: path.to_string_lossy().to_string(),
+                directories,
+                routes: routes,
+                middlewares,
+            };
+
+            Ok(dir_info)
+        } else {
+            // If it's not a directory, return an empty DirectoryInfo (though we don't push for non-dirs)
+            Ok(RouteDirectoryInfo {
+                path: path.to_string_lossy().to_string(),
+                directories: Vec::new(),
+                routes: HashMap::new(),
+                middlewares: Vec::new(),
+            })
+        }
+    }
+
+    pub fn has_middlewares(&self) -> bool {
+        !self.middlewares.is_empty()
+    }
+
+
+    pub fn get_middleware_module_import(&self) -> String {
+        let base_path = RouteDirectoryInfo::get_base_path();
+        let base_path_str = base_path.to_string_lossy();
+        let routes_path_str = format!("{base_path_str}{ROUTES_FOLDER_PATH}");
+        let mut module_import = self
+            .path
+            .as_str()
+            .to_string()
+            .replace(&routes_path_str, "")
+            .replacen('/', "", 1)
+            .replace('/', "_")
+            .replace('.', "_dot_")
+            .replace('-', "_hyphen_")
+            .to_lowercase();
+        if module_import != "" {
+            module_import += "_"
+        }
+
+        format!("{module_import}{MIDDLEWARE_FILENAME}")
+    }
+
+    pub fn get_base_path() -> PathBuf {
+        std::env::current_dir().expect("Failed to read current_dir")
+    }
+
+    pub fn should_collect_route(entry: &PathBuf) -> bool {
+        let file_extension = entry.extension().expect("Failed to read file extension");
+        let file_name = entry.file_stem().expect("Failed to read file name");
+
+        if IGNORE_EXTENSIONS.iter().any(|val| val == &file_extension) {
+            return false;
+        }
+
+        if IGNORE_FILES.iter().any(|val| val == &file_name) {
+            return false;
+        }
+        true
+    }
+
+    fn collect_route(entry: PathBuf, routes: HashMap<String, Route>) -> HashMap<String, Route> {
+        let mut ret_routes = routes.clone();
+        let base_path = RouteDirectoryInfo::get_base_path();
+        let base_path_str = base_path.to_string_lossy();
+        let path = entry
+            .to_str()
+            .expect("Failed to read entry as str")
+            .replace(&format!("{base_path_str}{ROUTES_FOLDER_PATH}"), "")
+            // Cleanup windows paths
+            .replace("\\", "/")
+            .replace(".rs", "")
+            .replace(".mdx", "")
+            .replace(".tsx", "");
+
+        if entry.extension().expect("failed to read entry extension") == "rs" {
+            if let Entry::Vacant(routes) = ret_routes.entry(path.clone()) {
+                let mut route = Route::new(path);
+                route.update_axum_info();
+                routes.insert(route);
+            } else {
+                let route = ret_routes.get_mut(&path).unwrap();
+                route.update_axum_info();
+            }
+            return ret_routes;
+        }
+        if let Entry::Vacant(routes) = ret_routes.entry(path.clone()) {
+            let route = Route::new(path);
+            routes.insert(route);
+        }
+        ret_routes
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct MiddlewareData {
+    pub middlewares: Vec<String>,
+}
+
+impl MiddlewareData {
+    pub fn new(path: &String) -> Option<Self> {
+        if !(std::fs::exists(&path).unwrap_or_default()) {
+            return None;
+        }
+        let middlewares = MiddlewareData::read_middleware_methods_from_file(&path);
+
+        Some(MiddlewareData { middlewares })
+    }
+
+    // Given an array of syn::Attribute, returns true if the segments are "tuono_lib" and "middleware"
+    fn has_middleware_attr(attrs: &[Attribute]) -> bool {
+        attrs.iter().any(|attr| {
+            let path = attr.path();
+
+            let segments: Vec<_> = path.segments.iter().map(|s| s.ident.to_string()).collect();
+
+            segments == ["tuono_lib", "middleware"]
+        })
+    }
+
+    // Reads a middlewares.rs file and returns a Vector of Strings representing functions that were decorated with the tuono_lib::middleware macro
+    fn read_middleware_methods_from_file(path: &str) -> Vec<String> {
+        let file = fs_extra::file::read_to_string(path).expect("Failed to read API file");
+        let syntax = syn::parse_file(&file).expect("Unable to parse file");
+        let mut result = Vec::new();
+
+        for item in syntax.items {
+            if let Item::Fn(func) = item {
+                if MiddlewareData::has_middleware_attr(&func.attrs) {
+                    result.push(func.sig.ident.to_string());
+                }
+            }
+        }
+        return result;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_has_middlewares() {
+        let dir_info = RouteDirectoryInfo {
+            middlewares: vec!["middleware1".to_string()],
+            ..Default::default()
+        };
+        assert!(dir_info.has_middlewares());
+
+        let dir_info_empty = RouteDirectoryInfo::default();
+        assert!(!dir_info_empty.has_middlewares());
+    }
+
+    #[test]
+    fn test_get_middleware_module_import() {
+        let dir_info = RouteDirectoryInfo {
+            path: "/some/path/src/routes".to_string(),
+            ..Default::default()
+        };
+        // Assuming base path is current dir, but this might vary
+        // For test, we can check the format
+        let import = dir_info.get_middleware_module_import();
+        assert!(import.ends_with("_middlewares"));
+    }
+
+    #[test]
+    fn test_get_base_path() {
+        let path = RouteDirectoryInfo::get_base_path();
+        assert!(path.is_absolute());
+    }
+
+    #[test]
+    fn test_should_collect_route() {
+        let temp_dir = TempDir::new().unwrap();
+        let rs_file = temp_dir.path().join("test.rs");
+        File::create(&rs_file).unwrap();
+        assert!(RouteDirectoryInfo::should_collect_route(&rs_file));
+
+        let tsx_file = temp_dir.path().join("test.tsx");
+        File::create(&tsx_file).unwrap();
+        assert!(RouteDirectoryInfo::should_collect_route(&tsx_file));
+
+        let md_file = temp_dir.path().join("test.md");
+        File::create(&md_file).unwrap();
+        assert!(RouteDirectoryInfo::should_collect_route(&md_file));
+    }
+
+    #[test]
+    fn test_collect_route() {
+        let temp_dir = TempDir::new().unwrap();
+        let rs_file = temp_dir.path().join("index.rs");
+        File::create(&rs_file).unwrap();
+
+        let routes = HashMap::new();
+        let new_routes = RouteDirectoryInfo::collect_route(rs_file, routes);
+        assert!(!new_routes.is_empty());
+    }
+
+    #[test]
+    fn test_route_directory_info_new() {
+        let temp_dir = TempDir::new().unwrap();
+        let sub_dir = temp_dir.path().join("sub");
+        std::fs::create_dir(&sub_dir).unwrap();
+        let file = temp_dir.path().join("test.rs");
+        File::create(&file).unwrap();
+        let middlewares_file = temp_dir.path().join("middlewares.rs");
+        let mut file = File::create(&middlewares_file).unwrap();
+        writeln!(file, "#[tuono_lib::middleware]\nfn test_middleware() {{}}").unwrap();
+
+        let dir_info = RouteDirectoryInfo::new(temp_dir.path()).unwrap();
+        assert_eq!(dir_info.path, temp_dir.path().to_string_lossy());
+        assert!(!dir_info.directories.is_empty());
+        assert!(!dir_info.middlewares.is_empty());
+    }
+
+    #[test]
+    fn test_middleware_data_new() {
+        let temp_dir = TempDir::new().unwrap();
+        let middlewares_file = temp_dir.path().join("middlewares.rs");
+        let mut file = File::create(&middlewares_file).unwrap();
+        writeln!(file, "#[tuono_lib::middleware]\nfn test_middleware() {{}}").unwrap();
+
+        let middleware_data = MiddlewareData::new(&middlewares_file.to_string_lossy().to_string()).unwrap();
+        assert_eq!(middleware_data.middlewares, vec!["test_middleware"]);
+    }
+
+    #[test]
+    fn test_has_middleware_attr() {
+        let attr: Attribute = syn::parse_quote!(#[tuono_lib::middleware]);
+        assert!(MiddlewareData::has_middleware_attr(&[attr]));
+
+        let attr2: Attribute = syn::parse_quote!(#[other_attr]);
+        assert!(!MiddlewareData::has_middleware_attr(&[attr2]));
+    }
+
+    #[test]
+    fn test_read_middleware_methods_from_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let middlewares_file = temp_dir.path().join("middlewares.rs");
+        let mut file = File::create(&middlewares_file).unwrap();
+        writeln!(file, "#[tuono_lib::middleware]\nfn test_middleware() {{}}\nfn other_fn() {{}}").unwrap();
+
+        let methods = MiddlewareData::read_middleware_methods_from_file(&middlewares_file.to_string_lossy());
+        assert_eq!(methods, vec!["test_middleware"]);
+    }
+}

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -218,6 +218,9 @@ impl SourceBuilder {
         for directory in route_directory_info.directories.clone() {
             route_declarations.push_str(&self.create_routes_declaration(&directory));
         }
+        if route_directory_info.has_middlewares() {
+            route_declarations.push_str(&self.add_route_layers(route_directory_info));
+        }
         for (_key, route) in routes {
             let Route { axum_info, .. } = &route;
             if !axum_info.is_some() {
@@ -244,9 +247,7 @@ impl SourceBuilder {
                 }
             }
         }
-        if route_directory_info.has_middlewares() {
-            route_declarations.push_str(&self.add_route_layers(route_directory_info));
-        }
+
         route_declarations.push_str(")\n");
         route_declarations
     }

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -110,7 +110,18 @@ impl SourceBuilder {
 
     fn generate_axum_source(&self) -> String {
         let Self { app, mode, .. } = &self;
-
+        let mut main_file_definition: &str = "";
+        let mut main_file_usage: &str = ";";
+        let mut mainfile_import: &str = "";
+        let mode_str = mode.as_str();
+        if app.has_app_state {
+            main_file_definition = "let user_custom_state = tuono_main_state::main().await;\n 
+            let router = Router::new()";
+            main_file_usage = ".with_state(user_custom_state);";
+            mainfile_import = r#"#[path="../src/app.rs"]
+            mod tuono_main_state;
+            "#;
+        }
         let src = AXUM_ENTRY_POINT
             .replace("\r", "")
             .replace(
@@ -122,33 +133,13 @@ impl SourceBuilder {
                 &self.create_modules_declaration(&app.route_directory_info),
             )
             .replace("/*VERSION*/", crate_version!())
-            .replace("/*MODE*/", mode.as_str())
             .replace(
-                "//MAIN_FILE_IMPORT//",
-                if app.has_app_state {
-                    r#"#[path="../src/app.rs"]
-                    mod tuono_main_state;
-                    "#
-                } else {
-                    ""
-                },
+                "/*MODE*/",
+                format!("const MODE: Mode = {mode_str};").as_ref(),
             )
-            .replace(
-                "//MAIN_FILE_DEFINITION//",
-                if app.has_app_state {
-                    "let user_custom_state = tuono_main_state::main();"
-                } else {
-                    ""
-                },
-            )
-            .replace(
-                "//MAIN_FILE_USAGE//",
-                if app.has_app_state {
-                    ".with_state(user_custom_state)"
-                } else {
-                    ""
-                },
-            );
+            .replace("//MAIN_FILE_IMPORT//", mainfile_import)
+            .replace("//MAIN_FILE_DEFINITION//", main_file_definition)
+            .replace("//MAIN_FILE_USAGE//", main_file_usage);
 
         let mut import_http_handler = String::new();
 
@@ -196,10 +187,11 @@ impl SourceBuilder {
 
         if route_directory_info.has_middlewares() {
             let middleware_import = &route_directory_info.get_middleware_module_import();
-            let layers = &route_directory_info.middlewares;
-            for layer in layers {
+            let layers = &route_directory_info.middlewares.lock().unwrap();
+            for layer in layers.iter() {
+                let middleware_fn_call = layer.fn_call_str.clone();
                 layers_str.push_str(&format!(
-                    r#".layer({middleware_import}::{layer}())
+                    r#".layer({middleware_import}::{middleware_fn_call})
                             "#
                 ));
             }
@@ -215,11 +207,9 @@ impl SourceBuilder {
         route_declarations.push_str(r#".merge(Router::new()"#);
         // Group by directory, find dirs with middleware, have that spit out Router::new() with routes and middlewares
 
+        // directories can have their own middlewares and routes, recurse into that directory to get route/middleware info
         for directory in route_directory_info.directories.clone() {
             route_declarations.push_str(&self.create_routes_declaration(&directory));
-        }
-        if route_directory_info.has_middlewares() {
-            route_declarations.push_str(&self.add_route_layers(route_directory_info));
         }
         for (_key, route) in routes {
             let Route { axum_info, .. } = &route;
@@ -249,6 +239,11 @@ impl SourceBuilder {
         }
 
         route_declarations.push_str(")\n");
+
+        // add directory level middleware to routes
+        if route_directory_info.has_middlewares() {
+            route_declarations.push_str(&self.add_route_layers(route_directory_info));
+        }
         route_declarations
     }
 

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -196,7 +196,7 @@ impl SourceBuilder {
                 ));
             }
         }
-        return layers_str;
+        layers_str
     }
 
     // Adds Routers with routes to axum
@@ -258,8 +258,8 @@ impl SourceBuilder {
 
         // add module import per route
         for (path, route) in routes.iter() {
-            if route.axum_info.is_some() {
-                let AxumInfo { module_import, .. } = route.axum_info.as_ref().unwrap();
+            if let Some(route_auxm_info) = &route.axum_info {
+                let AxumInfo { module_import, .. } = route_auxm_info;
 
                 module_declarations.push_str(&format!(
                     r#"#[path="../{ROUTE_FOLDER}{path}.rs"]

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -7,10 +7,12 @@ use std::path::PathBuf;
 use clap::crate_version;
 use tracing::error;
 
-use crate::app::App;
+use crate::app::{App, ROUTES_FOLDER_PATH};
 use crate::mode::Mode;
 use crate::route::AxumInfo;
 use crate::route::Route;
+use crate::route_directory_info::MIDDLEWARE_FILENAME;
+use crate::route_directory_info::RouteDirectoryInfo;
 use crate::typescript::TypesJar;
 
 #[cfg(not(target_os = "windows"))]
@@ -111,8 +113,14 @@ impl SourceBuilder {
 
         let src = AXUM_ENTRY_POINT
             .replace("\r", "")
-            .replace("// ROUTE_BUILDER\n", &self.create_routes_declaration())
-            .replace("// MODULE_IMPORTS\n", &self.create_modules_declaration())
+            .replace(
+                "// ROUTE_BUILDER\n",
+                &self.create_routes_declaration(&app.route_directory_info),
+            )
+            .replace(
+                "// MODULE_IMPORTS\n",
+                &self.create_modules_declaration(&app.route_directory_info),
+            )
             .replace("/*VERSION*/", crate_version!())
             .replace("/*MODE*/", mode.as_str())
             .replace(
@@ -182,58 +190,107 @@ impl SourceBuilder {
         self.types_jar.generate_typescript_file(&self.base_path)
     }
 
-    fn create_routes_declaration(&self) -> String {
-        let routes = &self.app.route_map;
+    // Adds calls to .layer() for adding middleware to axum
+    pub fn add_route_layers(&self, route_directory_info: &RouteDirectoryInfo) -> String {
+        let mut layers_str = String::from("");
+
+        if route_directory_info.has_middlewares() {
+            let middleware_import = &route_directory_info.get_middleware_module_import();
+            let layers = &route_directory_info.middlewares;
+            for layer in layers {
+                layers_str.push_str(&format!(
+                    r#".layer({middleware_import}::{layer}())
+                            "#
+                ));
+            }
+        }
+        return layers_str;
+    }
+
+    // Adds Routers with routes to axum
+    fn create_routes_declaration(&self, route_directory_info: &RouteDirectoryInfo) -> String {
+        let routes = route_directory_info.routes.clone();
         let mut route_declarations = String::from("// ROUTE_BUILDER\n");
 
-        for (_, route) in routes.iter() {
+        route_declarations.push_str(r#".merge(Router::new()"#);
+        // Group by directory, find dirs with middleware, have that spit out Router::new() with routes and middlewares
+
+        for directory in route_directory_info.directories.clone() {
+            route_declarations.push_str(&self.create_routes_declaration(&directory));
+        }
+        for (_key, route) in routes {
             let Route { axum_info, .. } = &route;
+            if !axum_info.is_some() {
+                continue;
+            }
+            let AxumInfo {
+                axum_route,
+                module_import,
+            } = axum_info.as_ref().unwrap();
+            if !route.is_api() {
+                route_declarations.push_str(&format!(
+                    r#".route("{axum_route}", get({module_import}::tuono_internal_route))"#
+                ));
 
-            if axum_info.is_some() {
-                let AxumInfo {
-                    axum_route,
-                    module_import,
-                } = axum_info.as_ref().unwrap();
-
-                if !route.is_api() {
+                route_declarations.push_str(&format!(
+                    r#".route("/__tuono/data{axum_route}", get({module_import}::tuono_internal_api))"#
+                ));
+            } else {
+                for method in route.api_data.as_ref().unwrap().methods.clone() {
+                    let method = method.to_string().to_lowercase();
                     route_declarations.push_str(&format!(
-                        r#".route("{axum_route}", get({module_import}::tuono_internal_route))"#
+                            r#".route("{axum_route}", {method}({module_import}::{method}_tuono_internal_api))"#
                     ));
-
-                    route_declarations.push_str(&format!(
-                            r#".route("/__tuono/data{axum_route}", get({module_import}::tuono_internal_api))"#
-                    ));
-                } else {
-                    for method in route.api_data.as_ref().unwrap().methods.clone() {
-                        let method = method.to_string().to_lowercase();
-                        route_declarations.push_str(&format!(
-                                r#".route("{axum_route}", {method}({module_import}::{method}_tuono_internal_api))"#
-                        ));
-                    }
                 }
             }
         }
-
+        if route_directory_info.has_middlewares() {
+            route_declarations.push_str(&self.add_route_layers(route_directory_info));
+        }
+        route_declarations.push_str(")\n");
         route_declarations
     }
 
-    fn create_modules_declaration(&self) -> String {
-        let routes = &self.app.route_map;
-        let mut route_declarations = String::from("// MODULE_IMPORTS\n");
+    fn create_modules_declaration(&self, route_directory_info: &RouteDirectoryInfo) -> String {
+        let routes = &route_directory_info.routes;
+        let mut module_declarations = String::from("// MODULE_IMPORTS\n");
 
+        // add subdirectory module declarations
+        for directory in route_directory_info.directories.clone() {
+            module_declarations.push_str(&self.create_modules_declaration(&directory));
+        }
+
+        // add module import per route
         for (path, route) in routes.iter() {
             if route.axum_info.is_some() {
                 let AxumInfo { module_import, .. } = route.axum_info.as_ref().unwrap();
 
-                route_declarations.push_str(&format!(
+                module_declarations.push_str(&format!(
                     r#"#[path="../{ROUTE_FOLDER}{path}.rs"]
                     mod {module_import};
                     "#
-                ))
+                ));
             }
         }
+        // add middleware module import as needed
+        if route_directory_info.has_middlewares() {
+            let path = &route_directory_info.path;
+            let base_path = RouteDirectoryInfo::get_base_path();
+            let base_path_str = base_path.to_string_lossy();
+            let routes_path_str = format!("{base_path_str}{ROUTES_FOLDER_PATH}");
 
-        route_declarations
+            let replaced_path = path.replace(&routes_path_str, "");
+            let module_path: String = format!("{replaced_path}/{MIDDLEWARE_FILENAME}");
+            let module_import = route_directory_info.get_middleware_module_import();
+
+            module_declarations.push_str(&format!(
+                r#"#[path="../{ROUTE_FOLDER}{module_path}.rs"]
+            mod {module_import};
+            "#
+            ));
+        }
+
+        module_declarations
     }
 
     fn build_html_fallback(&self) -> String {

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -110,7 +110,7 @@ impl SourceBuilder {
 
     fn generate_axum_source(&self) -> String {
         let Self { app, mode, .. } = &self;
-        let mut main_file_definition: &str = "";
+        let mut main_file_definition: &str = " let router = Router::new()";
         let mut main_file_usage: &str = ";";
         let mut mainfile_import: &str = "";
         let mode_str = mode.as_str();

--- a/crates/tuono/src/typescript/parser/utils.rs
+++ b/crates/tuono/src/typescript/parser/utils.rs
@@ -57,15 +57,14 @@ where
     T: Default + FromStr,
 {
     for attr in attrs {
-        if attr.path().is_ident("serde") {
-            if let Ok(meta) = attr.parse_args::<syn::Expr>() {
+        if attr.path().is_ident("serde")
+            && let Ok(meta) = attr.parse_args::<syn::Expr>() {
                 match meta {
                     syn::Expr::Assign(assign) => {
-                        if let syn::Expr::Path(path) = *assign.left {
-                            if !path.path.is_ident(attribute_name) {
+                        if let syn::Expr::Path(path) = *assign.left
+                            && !path.path.is_ident(attribute_name) {
                                 return T::default();
                             }
-                        }
                         if let syn::Expr::Lit(syn::ExprLit {
                             lit: syn::Lit::Str(lit_str),
                             ..
@@ -77,7 +76,6 @@ where
                     _ => return T::default(),
                 }
             }
-        }
     }
     T::default()
 }
@@ -86,13 +84,11 @@ where
 /// `#[serde(skip)]` or `#[serde(skip_serializing)]` attributes.
 pub fn should_skip_element(attrs: &[syn::Attribute]) -> bool {
     for attr in attrs {
-        if attr.path().is_ident("serde") {
-            if let Ok(meta) = attr.parse_args::<syn::Ident>() {
-                if meta == "skip" || meta == "skip_serializing" {
+        if attr.path().is_ident("serde")
+            && let Ok(meta) = attr.parse_args::<syn::Ident>()
+                && (meta == "skip" || meta == "skip_serializing") {
                     return true;
                 }
-            }
-        }
     }
     false
 }

--- a/crates/tuono/src/typescript/utils.rs
+++ b/crates/tuono/src/typescript/utils.rs
@@ -3,22 +3,20 @@ use syn::{Attribute, Meta};
 
 pub fn has_derive_type(attrs: &[Attribute]) -> bool {
     for attr in attrs {
-        if let Meta::List(meta_list) = &attr.meta {
-            if meta_list.path.is_ident("derive") {
+        if let Meta::List(meta_list) = &attr.meta
+            && meta_list.path.is_ident("derive") {
                 for nested_meta in meta_list
                     .parse_args_with(
                         syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
                     )
                     .unwrap_or_default()
                 {
-                    if let Meta::Path(path) = nested_meta {
-                        if path.is_ident(&TYPE_TRAIT) {
+                    if let Meta::Path(path) = nested_meta
+                        && path.is_ident(&TYPE_TRAIT) {
                             return true;
                         }
-                    }
                 }
             }
-        }
     }
     false
 }

--- a/crates/tuono/templates/server.rs
+++ b/crates/tuono/templates/server.rs
@@ -1,10 +1,10 @@
 // File automatically generated
 // Do not manually change it
 
-use tuono_lib::{tokio, Mode, Server, axum::Router, tuono_internal_init_v8_platform};
+use tuono_lib::{Mode, Server, axum::Router, tokio, tuono_internal_init_v8_platform};
 // AXUM_GET_ROUTE_HANDLER
 
-const MODE: Mode = /*MODE*/;
+/*MODE*/
 
 // MODULE_IMPORTS
 
@@ -13,17 +13,15 @@ const MODE: Mode = /*MODE*/;
 #[tokio::main]
 async fn main() {
     tuono_internal_init_v8_platform();
-    
+
     if MODE == Mode::Prod {
         println!("\n  ⚡ Tuono v/*VERSION*/");
     }
 
     //MAIN_FILE_DEFINITION//
 
-    let router = Router::new()
-        // ROUTE_BUILDER
-        //MAIN_FILE_USAGE//;
+    // ROUTE_BUILDER
+    //MAIN_FILE_USAGE//
 
     Server::init(router, MODE).await.start().await
 }
-

--- a/crates/tuono/tests/cli_build.rs
+++ b/crates/tuono/tests/cli_build.rs
@@ -251,3 +251,105 @@ fn build_fails_with_no_config() {
             "Cannot find tuono.config.ts - is this a tuono project?",
         ));
 }
+
+#[test]
+#[serial]
+fn it_successfully_adds_middleware_to_router() {
+    let temp_tuono_project = TempTuonoProject::new();
+
+    temp_tuono_project.add_file_with_content(
+        "./src/routes/middlewares.rs",
+        r#"use tower_http::trace::TraceLayer;
+
+#[tuono_lib::middleware]
+pub fn trace_layer() -> TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>> {
+    TraceLayer::new_for_http()
+}"#,
+    );
+
+    let mut test_tuono_build = Command::cargo_bin("tuono").unwrap();
+    test_tuono_build
+        .arg("build")
+        .arg("--no-js-emit")
+        .assert()
+        .success();
+
+    let temp_main_rs_path = temp_tuono_project.path().join(".tuono/main.rs");
+
+    let temp_main_rs_content =
+        fs::read_to_string(&temp_main_rs_path).expect("Failed to read '.tuono/main.rs' content.");
+
+    assert!(temp_main_rs_content.contains(r#"#[path="../src/routes/middlewares.rs"]"#));
+    assert!(temp_main_rs_content.contains("mod middlewares;"));
+    assert!(temp_main_rs_content.contains(".layer(middlewares::trace_layer())"));
+}
+
+#[test]
+#[serial]
+fn it_successfully_adds_multiple_middlewares_to_router() {
+    let temp_tuono_project = TempTuonoProject::new();
+
+    temp_tuono_project.add_file_with_content(
+        "./src/routes/middlewares.rs",
+        r#"use tower_http::trace::TraceLayer;
+
+#[tuono_lib::middleware]
+pub fn trace_layer() -> TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>> {
+    TraceLayer::new_for_http()
+}
+
+#[tuono_lib::middleware]
+pub fn another_middleware() -> tower_http::cors::CorsLayer {
+    tower_http::cors::CorsLayer::new()
+}"#,
+    );
+
+    let mut test_tuono_build = Command::cargo_bin("tuono").unwrap();
+    test_tuono_build
+        .arg("build")
+        .arg("--no-js-emit")
+        .assert()
+        .success();
+
+    let temp_main_rs_path = temp_tuono_project.path().join(".tuono/main.rs");
+
+    let temp_main_rs_content =
+        fs::read_to_string(&temp_main_rs_path).expect("Failed to read '.tuono/main.rs' content.");
+
+    assert!(temp_main_rs_content.contains(r#"#[path="../src/routes/middlewares.rs"]"#));
+    assert!(temp_main_rs_content.contains("mod middlewares;"));
+    assert!(temp_main_rs_content.contains(".layer(middlewares::trace_layer())"));
+    assert!(temp_main_rs_content.contains(".layer(middlewares::another_middleware())"));
+}
+
+#[test]
+#[serial]
+fn it_successfully_adds_middleware_in_subdirectory() {
+    let temp_tuono_project = TempTuonoProject::new();
+
+    temp_tuono_project.add_file_with_content(
+        "./src/routes/api/middlewares.rs",
+        r#"#[tuono_lib::middleware]
+pub fn api_middleware() -> tower_http::cors::CorsLayer {
+    tower_http::cors::CorsLayer::new()
+}"#,
+    );
+
+    temp_tuono_project.add_file("./src/routes/api/health.rs");
+
+    let mut test_tuono_build = Command::cargo_bin("tuono").unwrap();
+    test_tuono_build
+        .arg("build")
+        .arg("--no-js-emit")
+        .assert()
+        .success();
+
+    let temp_main_rs_path = temp_tuono_project.path().join(".tuono/main.rs");
+
+    let temp_main_rs_content =
+        fs::read_to_string(&temp_main_rs_path).expect("Failed to read '.tuono/main.rs' content.");
+
+    assert!(temp_main_rs_content.contains(r#"#[path="../src/routes/api/middlewares.rs"]"#));
+    assert!(temp_main_rs_content.contains("mod api_middlewares;"));
+    assert!(temp_main_rs_content.contains(".layer(api_middlewares::api_middleware())"));
+}

--- a/crates/tuono_lib/src/lib.rs
+++ b/crates/tuono_lib/src/lib.rs
@@ -22,7 +22,7 @@ pub use payload::Payload;
 pub use request::Request;
 pub use response::{Props, Response};
 pub use server::{Server, tuono_internal_init_v8_platform};
-pub use tuono_lib_macros::{Type, api, handler};
+pub use tuono_lib_macros::{Type, api, handler, middleware};
 
 // Re-exports
 pub use axum;

--- a/crates/tuono_lib/src/server.rs
+++ b/crates/tuono_lib/src/server.rs
@@ -54,11 +54,10 @@ impl Server {
         let _ = GLOBAL_MODE.set(mode);
         let _ = GLOBAL_CONFIG.set(config.clone());
 
-        if mode == Mode::Prod {
-            if let Err(err) = load_manifest() {
+        if mode == Mode::Prod
+            && let Err(err) = load_manifest() {
                 tuono_println!("Failed to load vite manifest: {}", err.to_string().red());
             }
-        }
 
         let server_address = format!("{}:{}", config.server.host, config.server.port);
 

--- a/crates/tuono_lib/src/vite_websocket_proxy.rs
+++ b/crates/tuono_lib/src/vite_websocket_proxy.rs
@@ -104,11 +104,10 @@ async fn handle_socket(mut tuono_socket: WebSocket) {
                 }
             };
 
-            if let Err(err) = tuono_sender.send(msg_to_browser).await {
-                if err.to_string() != Error::AlreadyClosed.to_string() {
+            if let Err(err) = tuono_sender.send(msg_to_browser).await
+                && err.to_string() != Error::AlreadyClosed.to_string() {
                     eprintln!("Failed to send back message from vite to browser: {err}")
                 }
-            }
         }
     });
 }

--- a/crates/tuono_lib_macros/src/lib.rs
+++ b/crates/tuono_lib_macros/src/lib.rs
@@ -9,6 +9,7 @@ use proc_macro::TokenStream;
 mod api;
 mod handler;
 mod utils;
+mod middleware;
 
 #[proc_macro_attribute]
 pub fn handler(args: TokenStream, item: TokenStream) -> TokenStream {
@@ -18,6 +19,11 @@ pub fn handler(args: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn api(args: TokenStream, item: TokenStream) -> TokenStream {
     api::api_core(args, item)
+}
+
+#[proc_macro_attribute]
+pub fn middleware(args: TokenStream, item: TokenStream) -> TokenStream {
+    middleware::middleware_core(args, item)
 }
 
 /// Automatically generate typescript's types

--- a/crates/tuono_lib_macros/src/lib.rs
+++ b/crates/tuono_lib_macros/src/lib.rs
@@ -8,8 +8,8 @@ use proc_macro::TokenStream;
 
 mod api;
 mod handler;
-mod utils;
 mod middleware;
+mod utils;
 
 #[proc_macro_attribute]
 pub fn handler(args: TokenStream, item: TokenStream) -> TokenStream {

--- a/crates/tuono_lib_macros/src/middleware.rs
+++ b/crates/tuono_lib_macros/src/middleware.rs
@@ -5,6 +5,7 @@ use syn::{ItemFn, parse_macro_input};
 pub fn middleware_core(_args: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
     quote! {
-        #item
-  }.into()
+          #item
+    }
+    .into()
 }

--- a/crates/tuono_lib_macros/src/middleware.rs
+++ b/crates/tuono_lib_macros/src/middleware.rs
@@ -1,0 +1,10 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{ItemFn, parse_macro_input};
+
+pub fn middleware_core(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemFn);
+    quote! {
+        #item
+  }.into()
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # ARGs obtained from the compose.yml file
 
 ARG BASE_OS=bookworm
-ARG RUST_VERSION=1.83
+ARG RUST_VERSION=1.88
 
 FROM rust:${RUST_VERSION}-${BASE_OS}
 
@@ -42,8 +42,7 @@ RUN ["corepack", "enable"]
 RUN ["corepack", "install"]
 
 ## Install Node.js dependencies (defined in package.json)
-
-RUN ["pnpm", "install", "--frozen-lockfile"]
+RUN ["pnpm", "install", "--frozen-lockfile", "--config.confirmModulesPurge=false"]
 
 ## Compile and add the directory with compiled binaries to the PATH for direct access
 

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -7,7 +7,7 @@ services:
       context: ../
       dockerfile: ./docker/Dockerfile
       args:
-        RUST_VERSION: 1.83 # if change, think to update the default ARGs in Dockerfile
+        RUST_VERSION: 1.88 # if change, think to update the default ARGs in Dockerfile
         BASE_OS: bookworm # if change, think to update the default ARGs in Dockerfile
     image: tuono-source-image
     ports:

--- a/e2e/fixtures/base/Cargo.toml
+++ b/e2e/fixtures/base/Cargo.toml
@@ -10,5 +10,4 @@ path = ".tuono/main.rs"
 [dependencies]
 tuono_lib = { path = "../../../crates/tuono_lib" } 
 serde = { version = "1.0.202", features = ["derive"] }
-tower-http = "0.6.8"
-
+tower-http = { version = "0.6.8", features = ["full"]}

--- a/e2e/fixtures/base/Cargo.toml
+++ b/e2e/fixtures/base/Cargo.toml
@@ -10,4 +10,5 @@ path = ".tuono/main.rs"
 [dependencies]
 tuono_lib = { path = "../../../crates/tuono_lib" } 
 serde = { version = "1.0.202", features = ["derive"] }
+tower-http = "0.6.8"
 

--- a/e2e/fixtures/base/src/routes/middlewares.rs
+++ b/e2e/fixtures/base/src/routes/middlewares.rs
@@ -1,0 +1,7 @@
+
+use tower_http::trace::TraceLayer;
+
+#[tuono_lib::middleware]
+pub fn trace_layer() -> TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>> {
+    TraceLayer::new_for_http()
+}

--- a/e2e/fixtures/base/src/routes/middlewares.rs
+++ b/e2e/fixtures/base/src/routes/middlewares.rs
@@ -1,7 +1,8 @@
-
 use tower_http::trace::TraceLayer;
 
 #[tuono_lib::middleware]
-pub fn trace_layer() -> TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>> {
+pub fn trace_layer(
+) -> TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>>
+{
     TraceLayer::new_for_http()
 }

--- a/examples/tuono-app/Cargo.toml
+++ b/examples/tuono-app/Cargo.toml
@@ -10,4 +10,4 @@ path = ".tuono/main.rs"
 [dependencies]
 tuono_lib = { path = "../../crates/tuono_lib/" }
 serde = { version = "1.0.202", features = ["derive"] }
-
+tower-http = "0.6.8"

--- a/examples/tuono-app/Cargo.toml
+++ b/examples/tuono-app/Cargo.toml
@@ -10,4 +10,4 @@ path = ".tuono/main.rs"
 [dependencies]
 tuono_lib = { path = "../../crates/tuono_lib/" }
 serde = { version = "1.0.202", features = ["derive"] }
-tower-http = "0.6.8"
+tower-http = { version = "0.6.8", features = ["full"]}

--- a/examples/tuono-app/src/routes/api/middlewares.rs
+++ b/examples/tuono-app/src/routes/api/middlewares.rs
@@ -1,0 +1,8 @@
+use axum::{BoxError, error_handling::HandleErrorLayer, http::StatusCode,};
+
+#[tuono_lib::middleware]
+pub fn api_error_layer() -> HandleErrorLayer  {
+  HandleErrorLayer::new(|_: BoxError| async {
+    StatusCode::REQUEST_TIMEOUT
+})
+}

--- a/examples/tuono-app/src/routes/api/middlewares.rs
+++ b/examples/tuono-app/src/routes/api/middlewares.rs
@@ -1,8 +1,11 @@
-use axum::{BoxError, error_handling::HandleErrorLayer, http::StatusCode,};
+use tower_http::cors::{Any, CorsLayer};
+use tuono_lib::axum::http::Method;
 
 #[tuono_lib::middleware]
-pub fn api_error_layer() -> HandleErrorLayer  {
-  HandleErrorLayer::new(|_: BoxError| async {
-    StatusCode::REQUEST_TIMEOUT
-})
+pub fn api_cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        // allow `GET` and `POST` when accessing the resource
+        .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::PATCH])
+        // allow requests from any origin
+        .allow_origin(Any)
 }

--- a/examples/tuono-app/src/routes/middlewares.rs
+++ b/examples/tuono-app/src/routes/middlewares.rs
@@ -1,0 +1,7 @@
+
+use tower_http::trace::TraceLayer;
+
+#[tuono_lib::middleware]
+pub fn trace_layer() -> TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>> {
+    TraceLayer::new_for_http()
+}

--- a/examples/tuono-app/src/routes/middlewares.rs
+++ b/examples/tuono-app/src/routes/middlewares.rs
@@ -1,7 +1,8 @@
-
 use tower_http::trace::TraceLayer;
 
 #[tuono_lib::middleware]
-pub fn trace_layer() -> TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>> {
+pub fn trace_layer(
+) -> TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>>
+{
     TraceLayer::new_for_http()
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "workspace",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
+  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad",
   "scripts": {
     "dev": "turbo dev --filter=./devtools/* --filter=./packages/*",
     "build": "turbo build --filter=./devtools/* --filter=./packages/*",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "workspace",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad",
+  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
   "scripts": {
     "dev": "turbo dev --filter=./devtools/* --filter=./packages/*",
     "build": "turbo build --filter=./devtools/* --filter=./packages/*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,10 +61,10 @@ importers:
         version: 0.13.6(@swc/core@1.13.0)(typescript@5.8.3)
       vite:
         specifier: 6.1.3
-        version: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+        version: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
       vite-plugin-externalize-deps:
         specifier: 0.9.0
-        version: 0.9.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
+        version: 0.9.0(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
 
   e2e/fixtures/base:
     dependencies:
@@ -291,7 +291,7 @@ importers:
         version: 19.1.8
       '@vitejs/plugin-react-swc':
         specifier: 3.11.0
-        version: 3.11.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
+        version: 3.11.0(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
       happy-dom:
         specifier: 18.0.1
         version: 18.0.1
@@ -300,7 +300,7 @@ importers:
         version: 19.1.0
       vite:
         specifier: 6.1.3
-        version: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+        version: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
       vite-config:
         specifier: workspace:*
         version: link:../../devtools/vite-config
@@ -410,16 +410,34 @@ packages:
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.8':
     resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.8':
     resolution: {integrity: sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.8':
@@ -428,16 +446,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.8':
     resolution: {integrity: sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.8':
     resolution: {integrity: sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.8':
@@ -446,10 +482,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.8':
     resolution: {integrity: sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.8':
@@ -458,10 +506,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.8':
     resolution: {integrity: sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.8':
@@ -470,10 +530,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.8':
     resolution: {integrity: sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.8':
@@ -482,10 +554,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.8':
     resolution: {integrity: sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.8':
@@ -494,10 +578,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.8':
     resolution: {integrity: sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.8':
@@ -506,16 +602,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.8':
     resolution: {integrity: sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.25.8':
     resolution: {integrity: sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.8':
@@ -524,10 +638,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.25.8':
     resolution: {integrity: sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.8':
@@ -542,11 +668,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.8':
     resolution: {integrity: sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.8':
     resolution: {integrity: sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==}
@@ -554,10 +692,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.8':
     resolution: {integrity: sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.8':
@@ -696,24 +846,28 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.62.0':
     resolution: {integrity: sha512-sKhAyRsP6DNeFMRevAN28HccFKEO6l3OqC8MuAV+HNzzyzUOKx2HGnYlkLxCmDZ7lyzzl7vA7YRQFBLYXgsWSA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-x64-gnu@0.62.0':
     resolution: {integrity: sha512-WAPgDelo20F5An0SW8X+0hWVPF7dHKhHwZo5doOt8Dn9NX6nONQCmEDUUPtp/BqISBxRFSH+rZbaENn8GGlBqg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.62.0':
     resolution: {integrity: sha512-JJ0WIPVXiuiWmPLKL+W3/OX1O5aDWMoX47eODKdNoM46bTcxIUe+wpHou731WuqhfrwACBi3Bsljn6VsIFPe9A==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-wasm32-wasi@0.62.0':
     resolution: {integrity: sha512-FuGOzv4FJWSBnG9jkCgZysU6ZMTKWHyHXEr40J1HjRnyw58bQ1sPfVmHZusNTSDCXmBlBz0ZuELLTJFHTI3DVQ==}
@@ -794,60 +948,70 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-gnu@0.77.3':
     resolution: {integrity: sha512-LgY4sT+bnt01l3Dxq3Zv19gMAsJ5kI7sdVvL3CNCtAj47h/Zdfxg7WlD+L+FJZ3sfTQ5n2SJ0WDiZm380isBxg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.62.0':
     resolution: {integrity: sha512-NoM2Ymf0oKBlxu1DFjBQ7fAAz92JQ1MgbLT6apR2UCmOn7xIZAiyYloyXM43qDf6nTOAs3zmH6kNcEPZ8KaDrg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-arm64-musl@0.77.3':
     resolution: {integrity: sha512-Fq72ARLt8iriotueGp7zaWjFpfYBpRS5WElmAtpZLIy/p1dNwBEDhVUIjAl+sU14y0odp+yaTRHM7ULnMYGZhQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.77.3':
     resolution: {integrity: sha512-jtq6JREdyZ6xdTFJGM5Gm068WCkoMwh3Fkm08rZ2TAu4qjISdkJvTQ1wiEDDz2F8sqAdmASDqxnE/2DJ6Z6Clg==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.77.3':
     resolution: {integrity: sha512-HQz++ZmT9xWU9KS24DE+8oVTeUPd/JQkbjL2uvr0+SWY3loPnLG3kFAOLE/xXgYG/0D24mZylbZUwhzYND4snw==}
     engines: {node: '>=14.0.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.62.0':
     resolution: {integrity: sha512-ltHIWB0eBT5iDt9hvC6LI90JV7DVbUdXzCjuNzUl/qcXXpKKLFjuRUuAs0npg3B+bsw75N2UKdwJ+E+mGf+D9A==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.77.3':
     resolution: {integrity: sha512-GcuFDJf/pxrfd2hq+gBytlnr/hiPn36JxuPXP0nToNG4SNa1gHT8K0bDxZuN2UjmZlWmIC8ELDdpVcNeZON+lQ==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.62.0':
     resolution: {integrity: sha512-PODsXb/+a/380bdoJVruJSNuRm362b2fqgoRcQyDliIYVIlyNjhuRluNnXZt3Rcn+NMJuD6bR4UNDGIQawoaEg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-x64-musl@0.77.3':
     resolution: {integrity: sha512-unhkqVg/jb/kghmiMCto8AGKm3uBwH2P5/GwR8jZkBjSFX7ekNu6/8P5IuIs5KDiZXzcjww84vCzQVBlql6WkA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-wasm32-wasi@0.62.0':
     resolution: {integrity: sha512-1Ws06cA9bm7sNTUopUJWVhWx+fimKaazjTCIARHJDkJZZLCBuUOFOLzThqVmu0go0D8PXYA9IVe1caqSVjoHYg==}
@@ -946,56 +1110,67 @@ packages:
     resolution: {integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     resolution: {integrity: sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution: {integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     resolution: {integrity: sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution: {integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     resolution: {integrity: sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution: {integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     resolution: {integrity: sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution: {integrity: sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.1':
     resolution: {integrity: sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.45.1':
     resolution: {integrity: sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==}
@@ -1038,24 +1213,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.0':
     resolution: {integrity: sha512-whskQCOUlLQT7MjnronpHmyHegBka5ig9JkQvecbqhWzRfdwN+c2xTJs3kQsWy2Vc2f1hcL3D8hGIwY5TwPxMQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.0':
     resolution: {integrity: sha512-51n4P4nv6rblXyH3zCEktvmR9uSAZ7+zbfeby0sxbj8LS/IKuVd7iCwD5dwMj4CxG9Fs+HgjN73dLQF/OerHhg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.0':
     resolution: {integrity: sha512-VMqelgvnXs27eQyhDf1S2O2MxSdchIH7c1tkxODRtu9eotcAeniNNgqqLjZ5ML0MGeRk/WpbsAY/GWi7eSpiHw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.0':
     resolution: {integrity: sha512-NLJmseWJngWeENgat+O/WB4ptNxtx2X4OfPnSG5a/A4sxcn2E4jq91OPvbeUQwDkH+ZQWKXmbXFzt7Nn661QYA==}
@@ -1128,24 +1307,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.0.6':
     resolution: {integrity: sha512-IoArz1vfuTR4rALXMUXI/GWWfx2EaO4gFNtBNkDNOYhlTD4NVEwE45nbBoojYiTulajI4c2XH8UmVEVJTOJKxA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.0.6':
     resolution: {integrity: sha512-QtsUfLkEAeWAC3Owx9Kg+7JdzE+k9drPhwTAXbXugYB9RZUnEWWx5x3q/au6TvUYcL+n0RBqDEO2gucZRvRFgQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.0.6':
     resolution: {integrity: sha512-QthvJqIji2KlGNwLcK/PPYo7w1Wsi/8NK0wAtRGbv4eOPdZHkQ9KUk+oCoP20oPO7i2a6X1aBAFQEL7i08nNMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.0.6':
     resolution: {integrity: sha512-+oka+dYX8jy9iP00DJ9Y100XsqvbqR5s0yfMZJuPR1H/lDVtDfsZiSix1UFBQ3X1HWxoEEl6iXNJHWd56TocVw==}
@@ -1349,31 +1532,37 @@ packages:
     resolution: {integrity: sha512-vtIu34luF1jRktlHtiwm2mjuE8oJCsFiFr8hT5+tFQdqFKjPhbJXn83LswKsOhy0GxAEevpXDI4xxEwkjuXIPA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.4.1':
     resolution: {integrity: sha512-H3PaOuGyhFXiyJd+09uPhGl4gocmhyi1BRzvsP8Lv5AQO3p3/ZY7WjV4t2NkBksm9tMjf3YbOVHyPWi2eWsNYw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.4.1':
     resolution: {integrity: sha512-4+GmJcaaFntCi1S01YByqp8wLMjV/FyQyHVGm0vedIhL1Vfx7uHkz/sZmKsidRwokBGuxi92GFmSzqT2O8KcNA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.4.1':
     resolution: {integrity: sha512-6RDQVCmtFYTlhy89D5ixTqo9bTQqFhvNN0Ey1wJs5r+01Dq15gPHRXv2jF2bQATtMrOfYwv+R2ZR9ew1N1N3YQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.4.1':
     resolution: {integrity: sha512-XpU9uzIkD86+19NjCXxlVPISMUrVXsXo5htxtuG+uJ59p5JauSRZsIxQxzzfKzkxEjdvANPM/lS1HFoX6A6QeA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.4.1':
     resolution: {integrity: sha512-3CDjG/spbTKCSHl66QP2ekHSD+H34i7utuDIM5gzoNBcZ1gTO0Op09Wx5cikXnhORRf9+HyDWzm37vU1PLSM1A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.4.1':
     resolution: {integrity: sha512-50tYhvbCTnuzMn7vmP8IV2UKF7ITo1oihygEYq9wW2DUb/Y+QMqBHJUSCABRngATjZ4shOK6f2+s0gQX6ElENQ==}
@@ -1734,6 +1923,11 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.25.8:
     resolution: {integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==}
@@ -2257,24 +2451,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.29.1:
     resolution: {integrity: sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.29.1:
     resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.29.1:
     resolution: {integrity: sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.29.1:
     resolution: {integrity: sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==}
@@ -3022,6 +3220,46 @@ packages:
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
 
+  vite@6.1.3:
+    resolution: {integrity: sha512-JMnf752ldN0UhZoPYXuWiRPsC2Z5hPy9JeUwfNSPBY8TyFZbSHRE1f6/WA8umOEJp0EN3zTddgNNSLT6Fc10UQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -3278,64 +3516,127 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.8':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.25.8':
     optional: true
 
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
   '@esbuild/android-arm@0.25.8':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.25.8':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.8':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.25.8':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.8':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.8':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.8':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.25.8':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.8':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.25.8':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.8':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.8':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.8':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.25.8':
     optional: true
 
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
   '@esbuild/linux-x64@0.25.8':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.8':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.8':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.8':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.8':
@@ -3344,13 +3645,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.8':
     optional: true
 
+  '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.8':
+    optional: true
+
+  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.8':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.8':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.25.8':
@@ -4064,11 +4377,11 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react-swc@3.11.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))':
+  '@vitejs/plugin-react-swc@3.11.0(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@swc/core': 1.13.0
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -4090,13 +4403,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))':
+  '@vitest/mocker@3.2.4(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4498,6 +4811,34 @@ snapshots:
       acorn: 8.14.1
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
+
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.25.8:
     optionalDependencies:
@@ -6231,7 +6572,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6246,9 +6587,21 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-externalize-deps@0.9.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))):
+  vite-plugin-externalize-deps@0.9.0(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))):
     dependencies:
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+
+  vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)):
+    dependencies:
+      esbuild: 0.24.2
+      postcss: 8.5.6
+      rollup: 4.45.1
+    optionalDependencies:
+      '@types/node': 22.16.5
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.29.1
+      sugarss: 4.0.1(postcss@8.5.6)
 
   vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)):
     dependencies:
@@ -6269,7 +6622,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
+      '@vitest/mocker': 3.2.4(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -6287,7 +6640,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
       vite-node: 3.2.4(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,10 +61,10 @@ importers:
         version: 0.13.6(@swc/core@1.13.0)(typescript@5.8.3)
       vite:
         specifier: 6.1.3
-        version: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+        version: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
       vite-plugin-externalize-deps:
         specifier: 0.9.0
-        version: 0.9.0(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
+        version: 0.9.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
 
   e2e/fixtures/base:
     dependencies:
@@ -291,7 +291,7 @@ importers:
         version: 19.1.8
       '@vitejs/plugin-react-swc':
         specifier: 3.11.0
-        version: 3.11.0(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
+        version: 3.11.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
       happy-dom:
         specifier: 18.0.1
         version: 18.0.1
@@ -300,7 +300,7 @@ importers:
         version: 19.1.0
       vite:
         specifier: 6.1.3
-        version: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+        version: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
       vite-config:
         specifier: workspace:*
         version: link:../../devtools/vite-config
@@ -410,34 +410,16 @@ packages:
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
-  '@esbuild/aix-ppc64@0.24.2':
-    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.25.8':
     resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.24.2':
-    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.8':
     resolution: {integrity: sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.24.2':
-    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.8':
@@ -446,34 +428,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.24.2':
-    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.8':
     resolution: {integrity: sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.24.2':
-    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.8':
     resolution: {integrity: sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.24.2':
-    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.8':
@@ -482,22 +446,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.8':
     resolution: {integrity: sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.24.2':
-    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.8':
@@ -506,22 +458,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.24.2':
-    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.8':
     resolution: {integrity: sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.24.2':
-    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.8':
@@ -530,22 +470,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.24.2':
-    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.8':
     resolution: {integrity: sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.24.2':
-    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.8':
@@ -554,22 +482,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.24.2':
-    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.8':
     resolution: {integrity: sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.24.2':
-    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.8':
@@ -578,22 +494,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.24.2':
-    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.8':
     resolution: {integrity: sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.24.2':
-    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.8':
@@ -602,34 +506,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.24.2':
-    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.25.8':
     resolution: {integrity: sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.25.8':
     resolution: {integrity: sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.24.2':
-    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.8':
@@ -638,22 +524,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.25.8':
     resolution: {integrity: sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.24.2':
-    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.8':
@@ -668,23 +542,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.24.2':
-    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.8':
     resolution: {integrity: sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.24.2':
-    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.25.8':
     resolution: {integrity: sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==}
@@ -692,22 +554,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.24.2':
-    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.8':
     resolution: {integrity: sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.24.2':
-    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.8':
@@ -846,28 +696,24 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.62.0':
     resolution: {integrity: sha512-sKhAyRsP6DNeFMRevAN28HccFKEO6l3OqC8MuAV+HNzzyzUOKx2HGnYlkLxCmDZ7lyzzl7vA7YRQFBLYXgsWSA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-x64-gnu@0.62.0':
     resolution: {integrity: sha512-WAPgDelo20F5An0SW8X+0hWVPF7dHKhHwZo5doOt8Dn9NX6nONQCmEDUUPtp/BqISBxRFSH+rZbaENn8GGlBqg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.62.0':
     resolution: {integrity: sha512-JJ0WIPVXiuiWmPLKL+W3/OX1O5aDWMoX47eODKdNoM46bTcxIUe+wpHou731WuqhfrwACBi3Bsljn6VsIFPe9A==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-wasm32-wasi@0.62.0':
     resolution: {integrity: sha512-FuGOzv4FJWSBnG9jkCgZysU6ZMTKWHyHXEr40J1HjRnyw58bQ1sPfVmHZusNTSDCXmBlBz0ZuELLTJFHTI3DVQ==}
@@ -948,70 +794,60 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-gnu@0.77.3':
     resolution: {integrity: sha512-LgY4sT+bnt01l3Dxq3Zv19gMAsJ5kI7sdVvL3CNCtAj47h/Zdfxg7WlD+L+FJZ3sfTQ5n2SJ0WDiZm380isBxg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.62.0':
     resolution: {integrity: sha512-NoM2Ymf0oKBlxu1DFjBQ7fAAz92JQ1MgbLT6apR2UCmOn7xIZAiyYloyXM43qDf6nTOAs3zmH6kNcEPZ8KaDrg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-arm64-musl@0.77.3':
     resolution: {integrity: sha512-Fq72ARLt8iriotueGp7zaWjFpfYBpRS5WElmAtpZLIy/p1dNwBEDhVUIjAl+sU14y0odp+yaTRHM7ULnMYGZhQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.77.3':
     resolution: {integrity: sha512-jtq6JREdyZ6xdTFJGM5Gm068WCkoMwh3Fkm08rZ2TAu4qjISdkJvTQ1wiEDDz2F8sqAdmASDqxnE/2DJ6Z6Clg==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.77.3':
     resolution: {integrity: sha512-HQz++ZmT9xWU9KS24DE+8oVTeUPd/JQkbjL2uvr0+SWY3loPnLG3kFAOLE/xXgYG/0D24mZylbZUwhzYND4snw==}
     engines: {node: '>=14.0.0'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.62.0':
     resolution: {integrity: sha512-ltHIWB0eBT5iDt9hvC6LI90JV7DVbUdXzCjuNzUl/qcXXpKKLFjuRUuAs0npg3B+bsw75N2UKdwJ+E+mGf+D9A==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.77.3':
     resolution: {integrity: sha512-GcuFDJf/pxrfd2hq+gBytlnr/hiPn36JxuPXP0nToNG4SNa1gHT8K0bDxZuN2UjmZlWmIC8ELDdpVcNeZON+lQ==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.62.0':
     resolution: {integrity: sha512-PODsXb/+a/380bdoJVruJSNuRm362b2fqgoRcQyDliIYVIlyNjhuRluNnXZt3Rcn+NMJuD6bR4UNDGIQawoaEg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-x64-musl@0.77.3':
     resolution: {integrity: sha512-unhkqVg/jb/kghmiMCto8AGKm3uBwH2P5/GwR8jZkBjSFX7ekNu6/8P5IuIs5KDiZXzcjww84vCzQVBlql6WkA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-wasm32-wasi@0.62.0':
     resolution: {integrity: sha512-1Ws06cA9bm7sNTUopUJWVhWx+fimKaazjTCIARHJDkJZZLCBuUOFOLzThqVmu0go0D8PXYA9IVe1caqSVjoHYg==}
@@ -1110,67 +946,56 @@ packages:
     resolution: {integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     resolution: {integrity: sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution: {integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     resolution: {integrity: sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution: {integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     resolution: {integrity: sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution: {integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     resolution: {integrity: sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution: {integrity: sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.1':
     resolution: {integrity: sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.45.1':
     resolution: {integrity: sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==}
@@ -1213,28 +1038,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.0':
     resolution: {integrity: sha512-whskQCOUlLQT7MjnronpHmyHegBka5ig9JkQvecbqhWzRfdwN+c2xTJs3kQsWy2Vc2f1hcL3D8hGIwY5TwPxMQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.0':
     resolution: {integrity: sha512-51n4P4nv6rblXyH3zCEktvmR9uSAZ7+zbfeby0sxbj8LS/IKuVd7iCwD5dwMj4CxG9Fs+HgjN73dLQF/OerHhg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.0':
     resolution: {integrity: sha512-VMqelgvnXs27eQyhDf1S2O2MxSdchIH7c1tkxODRtu9eotcAeniNNgqqLjZ5ML0MGeRk/WpbsAY/GWi7eSpiHw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.0':
     resolution: {integrity: sha512-NLJmseWJngWeENgat+O/WB4ptNxtx2X4OfPnSG5a/A4sxcn2E4jq91OPvbeUQwDkH+ZQWKXmbXFzt7Nn661QYA==}
@@ -1307,28 +1128,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.0.6':
     resolution: {integrity: sha512-IoArz1vfuTR4rALXMUXI/GWWfx2EaO4gFNtBNkDNOYhlTD4NVEwE45nbBoojYiTulajI4c2XH8UmVEVJTOJKxA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.0.6':
     resolution: {integrity: sha512-QtsUfLkEAeWAC3Owx9Kg+7JdzE+k9drPhwTAXbXugYB9RZUnEWWx5x3q/au6TvUYcL+n0RBqDEO2gucZRvRFgQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.0.6':
     resolution: {integrity: sha512-QthvJqIji2KlGNwLcK/PPYo7w1Wsi/8NK0wAtRGbv4eOPdZHkQ9KUk+oCoP20oPO7i2a6X1aBAFQEL7i08nNMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.0.6':
     resolution: {integrity: sha512-+oka+dYX8jy9iP00DJ9Y100XsqvbqR5s0yfMZJuPR1H/lDVtDfsZiSix1UFBQ3X1HWxoEEl6iXNJHWd56TocVw==}
@@ -1532,37 +1349,31 @@ packages:
     resolution: {integrity: sha512-vtIu34luF1jRktlHtiwm2mjuE8oJCsFiFr8hT5+tFQdqFKjPhbJXn83LswKsOhy0GxAEevpXDI4xxEwkjuXIPA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.4.1':
     resolution: {integrity: sha512-H3PaOuGyhFXiyJd+09uPhGl4gocmhyi1BRzvsP8Lv5AQO3p3/ZY7WjV4t2NkBksm9tMjf3YbOVHyPWi2eWsNYw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.4.1':
     resolution: {integrity: sha512-4+GmJcaaFntCi1S01YByqp8wLMjV/FyQyHVGm0vedIhL1Vfx7uHkz/sZmKsidRwokBGuxi92GFmSzqT2O8KcNA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.4.1':
     resolution: {integrity: sha512-6RDQVCmtFYTlhy89D5ixTqo9bTQqFhvNN0Ey1wJs5r+01Dq15gPHRXv2jF2bQATtMrOfYwv+R2ZR9ew1N1N3YQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.4.1':
     resolution: {integrity: sha512-XpU9uzIkD86+19NjCXxlVPISMUrVXsXo5htxtuG+uJ59p5JauSRZsIxQxzzfKzkxEjdvANPM/lS1HFoX6A6QeA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.4.1':
     resolution: {integrity: sha512-3CDjG/spbTKCSHl66QP2ekHSD+H34i7utuDIM5gzoNBcZ1gTO0Op09Wx5cikXnhORRf9+HyDWzm37vU1PLSM1A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.4.1':
     resolution: {integrity: sha512-50tYhvbCTnuzMn7vmP8IV2UKF7ITo1oihygEYq9wW2DUb/Y+QMqBHJUSCABRngATjZ4shOK6f2+s0gQX6ElENQ==}
@@ -1923,11 +1734,6 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
-
-  esbuild@0.24.2:
-    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.25.8:
     resolution: {integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==}
@@ -2451,28 +2257,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.29.1:
     resolution: {integrity: sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.29.1:
     resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.29.1:
     resolution: {integrity: sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.29.1:
     resolution: {integrity: sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==}
@@ -3220,46 +3022,6 @@ packages:
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  vite@6.1.3:
-    resolution: {integrity: sha512-JMnf752ldN0UhZoPYXuWiRPsC2Z5hPy9JeUwfNSPBY8TyFZbSHRE1f6/WA8umOEJp0EN3zTddgNNSLT6Fc10UQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -3516,127 +3278,64 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.24.2':
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.8':
-    optional: true
-
-  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.25.8':
     optional: true
 
-  '@esbuild/android-arm@0.24.2':
-    optional: true
-
   '@esbuild/android-arm@0.25.8':
-    optional: true
-
-  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.25.8':
     optional: true
 
-  '@esbuild/darwin-arm64@0.24.2':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.8':
-    optional: true
-
-  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.25.8':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.8':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.8':
     optional: true
 
-  '@esbuild/linux-arm64@0.24.2':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.8':
-    optional: true
-
-  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.25.8':
     optional: true
 
-  '@esbuild/linux-ia32@0.24.2':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.8':
-    optional: true
-
-  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.25.8':
     optional: true
 
-  '@esbuild/linux-mips64el@0.24.2':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.8':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.8':
     optional: true
 
-  '@esbuild/linux-riscv64@0.24.2':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.8':
-    optional: true
-
-  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.25.8':
     optional: true
 
-  '@esbuild/linux-x64@0.24.2':
-    optional: true
-
   '@esbuild/linux-x64@0.25.8':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.8':
     optional: true
 
-  '@esbuild/netbsd-x64@0.24.2':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.8':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.25.8':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.8':
@@ -3645,25 +3344,13 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.8':
     optional: true
 
-  '@esbuild/sunos-x64@0.24.2':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.8':
-    optional: true
-
-  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.8':
     optional: true
 
-  '@esbuild/win32-ia32@0.24.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.8':
-    optional: true
-
-  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.25.8':
@@ -4377,11 +4064,11 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react-swc@3.11.0(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))':
+  '@vitejs/plugin-react-swc@3.11.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@swc/core': 1.13.0
-      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -4403,13 +4090,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))':
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4811,34 +4498,6 @@ snapshots:
       acorn: 8.14.1
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
-
-  esbuild@0.24.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.24.2
-      '@esbuild/android-arm': 0.24.2
-      '@esbuild/android-arm64': 0.24.2
-      '@esbuild/android-x64': 0.24.2
-      '@esbuild/darwin-arm64': 0.24.2
-      '@esbuild/darwin-x64': 0.24.2
-      '@esbuild/freebsd-arm64': 0.24.2
-      '@esbuild/freebsd-x64': 0.24.2
-      '@esbuild/linux-arm': 0.24.2
-      '@esbuild/linux-arm64': 0.24.2
-      '@esbuild/linux-ia32': 0.24.2
-      '@esbuild/linux-loong64': 0.24.2
-      '@esbuild/linux-mips64el': 0.24.2
-      '@esbuild/linux-ppc64': 0.24.2
-      '@esbuild/linux-riscv64': 0.24.2
-      '@esbuild/linux-s390x': 0.24.2
-      '@esbuild/linux-x64': 0.24.2
-      '@esbuild/netbsd-arm64': 0.24.2
-      '@esbuild/netbsd-x64': 0.24.2
-      '@esbuild/openbsd-arm64': 0.24.2
-      '@esbuild/openbsd-x64': 0.24.2
-      '@esbuild/sunos-x64': 0.24.2
-      '@esbuild/win32-arm64': 0.24.2
-      '@esbuild/win32-ia32': 0.24.2
-      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.25.8:
     optionalDependencies:
@@ -6572,7 +6231,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6587,21 +6246,9 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-externalize-deps@0.9.0(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))):
+  vite-plugin-externalize-deps@0.9.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))):
     dependencies:
-      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
-
-  vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)):
-    dependencies:
-      esbuild: 0.24.2
-      postcss: 8.5.6
-      rollup: 4.45.1
-    optionalDependencies:
-      '@types/node': 22.16.5
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      lightningcss: 1.29.1
-      sugarss: 4.0.1(postcss@8.5.6)
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
 
   vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)):
     dependencies:
@@ -6622,7 +6269,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6)))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -6640,7 +6287,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.1.3(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
       vite-node: 3.2.4(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.29.1)(sugarss@4.0.1(postcss@8.5.6))
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Checklist

- [X] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes #760 

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

This PR adds in middleware support through use of a `tuono_lib::middleware` macro on functions inside of `middlewares.rs` files in the React project's routes directory.

E.g. If a `middlewares.rs` file is in `src/routes/middlewares.rs` and has the following contents:

```
use tower_http::trace::TraceLayer;
use tower_http::cors::CorsLayer;

#[tuono_lib::middleware]
pub fn trace_layer() -> TraceLayer<tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>> {
    TraceLayer::new_for_http()
}

#[tuono_lib::middleware]
pub fn cors_layer() -> CorsLayer {
  CorsLayer::permissive()
}

```

Then all of the routes will get layered with the following middleware: `middlewares::trace_layer()` and `middlewares::cors_layer()`