### PR TITLE
fix: resolve critical css lookup for mdx routes

### DIFF
--- a/packages/tuono-react-vite-plugin/src/styles.spec.ts
+++ b/packages/tuono-react-vite-plugin/src/styles.spec.ts
@@ -1,0 +1,42 @@
+import path from 'path'
+
+import { describe, expect, it } from 'vitest'
+
+import { getStylesForComponentId } from './styles'
+
+describe('getStylesForComponentId', () => {
+  it('falls back to mdx route files when fetching critical css', async () => {
+    const calls: string[] = []
+    const expectedRoutePath = path.join(process.cwd(), 'src/routes/about')
+    const aboutMdxNode = {
+      file: `${expectedRoutePath}.mdx`,
+      url: '/src/routes/about.mdx',
+      importedModules: new Set(),
+      ssrTransformResult: { deps: [] },
+    }
+
+    const viteDevServer = {
+      moduleGraph: {
+        getModuleByUrl: async (url: string) => {
+          calls.push(url)
+          return url === expectedRoutePath ? undefined : aboutMdxNode
+        },
+      },
+      transformRequest: async (url: string) => {
+        calls.push(`transform:${url}`)
+        return undefined
+      },
+      ssrLoadModule: async () => ({ default: '' }),
+    }
+
+    const css = await getStylesForComponentId(
+      viteDevServer as never,
+      'about',
+      {},
+    )
+
+    expect(calls).toContain(expectedRoutePath)
+    expect(calls).toContain(`${expectedRoutePath}.mdx`)
+    expect(css).toBeUndefined()
+  })
+})

--- a/packages/tuono-react-vite-plugin/src/styles.ts
+++ b/packages/tuono-react-vite-plugin/src/styles.ts
@@ -167,8 +167,21 @@ export const getStylesForComponentId = async (
   )
 
   const fileUrl = path.join(process.cwd(), relativeFilePath)
+  const styles = await getStylesForModule(
+    viteDevServer,
+    fileUrl,
+    cssModulesManifest,
+  )
 
-  return await getStylesForModule(viteDevServer, fileUrl, cssModulesManifest)
+  if (styles !== undefined || path.extname(fileUrl) !== '') {
+    return styles
+  }
+
+  return await getStylesForModule(
+    viteDevServer,
+    `${fileUrl}.mdx`,
+    cssModulesManifest,
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a regression test covering critical CSS lookup for MDX routes
- retry the dev critical CSS lookup with an `.mdx` suffix when a route path has no extension

## Testing
- failing before fix: `pnpm --filter tuono-react-vite-plugin test -- packages/tuono-react-vite-plugin/src/styles.spec.ts`
- passing after fix: `pnpm --filter tuono-react-vite-plugin test -- packages/tuono-react-vite-plugin/src/styles.spec.ts`
- passing after fix: `pnpm --filter tuono-react-vite-plugin test`

Closes #772