### PR TITLE
test(e2e): add env variable tests for server and client

### DIFF
--- a/e2e/fixtures/base/.env
+++ b/e2e/fixtures/base/.env
@@ -1,0 +1,2 @@
+SERVER_TEST_VAR=server_value_from_env
+TUONO_PUBLIC_TEST_VAR=public_value_from_env

--- a/e2e/fixtures/base/src/routes/env-vars/index.rs
+++ b/e2e/fixtures/base/src/routes/env-vars/index.rs
@@ -1,0 +1,16 @@
+use serde::Serialize;
+use tuono_lib::{Props, Request, Response, Type};
+
+#[derive(Serialize, Type)]
+struct EnvVarsResponse {
+    server_var: String,
+    public_var: String,
+}
+
+#[tuono_lib::handler]
+async fn get_server_side_props(_req: Request) -> Response {
+    Response::Props(Props::new(EnvVarsResponse {
+        server_var: std::env::var("SERVER_TEST_VAR").unwrap_or_default(),
+        public_var: std::env::var("TUONO_PUBLIC_TEST_VAR").unwrap_or_default(),
+    }))
+}

--- a/e2e/fixtures/base/src/routes/env-vars/index.tsx
+++ b/e2e/fixtures/base/src/routes/env-vars/index.tsx
@@ -1,0 +1,23 @@
+import type { JSX } from 'react'
+import type { TuonoRouteProps } from 'tuono'
+import type { EnvVarsResponse } from 'tuono/types'
+
+export default function EnvVarsPage({
+  data,
+  isLoading,
+}: TuonoRouteProps<EnvVarsResponse>): JSX.Element {
+  if (isLoading) {
+    return <h1>Loading...</h1>
+  }
+
+  return (
+    <>
+      <h1>Env Vars</h1>
+      <p data-testid="server-var">{data.server_var}</p>
+      <p data-testid="public-var-server">{data.public_var}</p>
+      <p data-testid="public-var-client">
+        {import.meta.env.TUONO_PUBLIC_TEST_VAR}
+      </p>
+    </>
+  )
+}

--- a/e2e/fixtures/base/tests/e2e.spec.ts
+++ b/e2e/fixtures/base/tests/e2e.spec.ts
@@ -21,3 +21,25 @@ test('it routes to second route on link click', async ({ page }) => {
   const header = await page.textContent('h1')
   expect(header).toContain('Second route')
 })
+
+test('it reads server-side env variable from .env file', async ({ page }) => {
+  await page.goto('/env-vars')
+  const serverVar = await page.textContent('[data-testid="server-var"]')
+  expect(serverVar).toBe('server_value_from_env')
+})
+
+test('it reads TUONO_PUBLIC_ env variable on the server', async ({ page }) => {
+  await page.goto('/env-vars')
+  const publicVarServer = await page.textContent(
+    '[data-testid="public-var-server"]',
+  )
+  expect(publicVarServer).toBe('public_value_from_env')
+})
+
+test('it reads TUONO_PUBLIC_ env variable on the client', async ({ page }) => {
+  await page.goto('/env-vars')
+  const publicVarClient = await page.textContent(
+    '[data-testid="public-var-client"]',
+  )
+  expect(publicVarClient).toBe('public_value_from_env')
+})


### PR DESCRIPTION
### Checklist

- [x] I have read [Contributing > Pull requests](https://tuono.dev/documentation/contributing/pull-requests)

### Related issue

Fixes #634

### Overview

Add e2e tests verifying that `.env` file variables are correctly loaded on both server and client sides.

**What's added:**
- `.env` file in the base e2e fixture with `SERVER_TEST_VAR` and `TUONO_PUBLIC_TEST_VAR`
- Server-side route handler (`index.rs`) that reads both variables via `std::env::var` with `unwrap_or_default`
- Client-side component (`index.tsx`) that renders the server-provided values and the client-side `import.meta.env.TUONO_PUBLIC_TEST_VAR`
- Three e2e tests:
  1. Server-side env variable loads correctly
  2. `TUONO_PUBLIC_` prefixed variable is available on the server
  3. `TUONO_PUBLIC_` prefixed variable is available on the client via `import.meta.env`